### PR TITLE
2 global trigger parameters and a new efect

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectIgnite.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectIgnite.kt
@@ -1,6 +1,7 @@
 package com.willfp.libreforge.effects.effects
 
 import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ConfigViolation
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
@@ -13,14 +14,15 @@ class EffectIgnite: Effect(
     "ignite",
     true,
     Triggers.withParameters(
-        TriggerParameter.VICTIM
+        TriggerParameter.VICTIM,
+        TriggerParameter.PLAYER
     )
 ) {
 
     override fun handle(data: TriggerData, config: Config) {
         val victim = data.victim ?: return
-        val damage = config.getDouble("damage-per-tick")
-        val duration = config.getInt("ticks")
+        val damage = config.getDoubleFromExpression("damage-per-tick", data.player)
+        val duration = config.getIntFromExpression("ticks", data.player)
 
         victim.fireTicks = duration
         victim.setMetadata("ignitedMob", FixedMetadataValue(plugin, damage))
@@ -31,6 +33,23 @@ class EffectIgnite: Effect(
         if (event.cause != EntityDamageEvent.DamageCause.FIRE_TICK) return
         if (!event.entity.hasMetadata("ignitedMob")) return
         event.damage = event.entity.getMetadata("ignitedMob")[0].asDouble()
+    }
+
+    override fun validateConfig(config: Config): List<ConfigViolation> {
+        val violations = mutableListOf<ConfigViolation>()
+        if (!config.has("damage-per-tick")) violations.add(
+            ConfigViolation(
+                "damage-per-tick",
+                "You must specify the damage of fire per tick!"
+            )
+        )
+        if (!config.has("ticks")) violations.add(
+            ConfigViolation(
+                "ticks",
+                "You must specify the duration of igniting in ticks!"
+            )
+        )
+        return violations
     }
 
 }

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectIgnite.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectIgnite.kt
@@ -1,0 +1,36 @@
+package com.willfp.libreforge.effects.effects
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import com.willfp.libreforge.triggers.Triggers
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.metadata.FixedMetadataValue
+
+class EffectIgnite: Effect(
+    "ignite",
+    true,
+    Triggers.withParameters(
+        TriggerParameter.VICTIM
+    )
+) {
+
+    override fun handle(data: TriggerData, config: Config) {
+        val victim = data.victim ?: return
+        val damage = config.getDouble("damage-per-tick")
+        val duration = config.getInt("ticks")
+
+        victim.fireTicks = duration
+        victim.setMetadata("ignitedMob", FixedMetadataValue(plugin, damage))
+    }
+
+    @EventHandler
+    fun onBurn(event: EntityDamageEvent) {
+        if (event.cause != EntityDamageEvent.DamageCause.FIRE_TICK) return
+        if (!event.entity.hasMetadata("ignitedMob")) return
+        event.damage = event.entity.getMetadata("ignitedMob")[0].asDouble()
+    }
+
+}

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/Trigger.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/Trigger.kt
@@ -1,5 +1,6 @@
 package com.willfp.libreforge.triggers
 
+import com.willfp.eco.core.integrations.antigrief.AntigriefManager
 import com.willfp.eco.core.integrations.economy.EconomyManager
 import com.willfp.eco.util.NumberUtils
 import com.willfp.libreforge.Holder
@@ -44,6 +45,12 @@ abstract class Trigger(
                     continue
                 }
 
+                if (config.has("antigrief-check") && config.getBool("antigrief-check") && data.player != null && data.victim != null) {
+                    if (!AntigriefManager.canInjure(data.player, data.victim)) {
+                        continue
+                    }
+                }
+
                 val every = config.getIntOrNull("every") ?: 0
 
                 if (every > 0) {
@@ -74,7 +81,9 @@ abstract class Trigger(
                 }
 
                 if (effect.getCooldown(player, uuid) > 0) {
-                    effect.sendCooldownMessage(player, uuid)
+                    if (config.getBoolOrNull("send-cooldown-message") != false) {
+                        effect.sendCooldownMessage(player, uuid)
+                    }
                     continue
                 }
 


### PR DESCRIPTION
Added "antigrief-check: true/false" parameter to every victimable trigger. 

Added "send-cooldown-message: true/false" (true by default) parameter to every cooldownable trigger. 

Added Ignite effect with "ticks: int" and "damage-per-tick: double" parmeters to burn victim.