### PR TITLE
Multiplier as function

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/Effect.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/Effect.kt
@@ -100,4 +100,4 @@ abstract class Effect @JvmOverloads constructor(
     }
 }
 
-data class MultiplierModifier(val uuid: UUID, val multiplier: Double)
+data class MultiplierModifier(val uuid: UUID, val multiplier: () -> Double)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectFoodMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectFoodMultiplier.kt
@@ -26,9 +26,8 @@ class EffectFoodMultiplier : Effect("food_multiplier") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("multiplier", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("multiplier", player) }
         )
         modifiers[player.uniqueId] = registeredModifiers
     }
@@ -58,7 +57,7 @@ class EffectFoodMultiplier : Effect("food_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (modifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         val wrapped = WrappedHungerEvent(event)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectHungerMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectHungerMultiplier.kt
@@ -27,9 +27,8 @@ class EffectHungerMultiplier : Effect("hunger_multiplier") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("multiplier", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("multiplier", player) }
         )
         modifiers[player.uniqueId] = registeredModifiers
     }
@@ -59,7 +58,7 @@ class EffectHungerMultiplier : Effect("hunger_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (modifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         val wrapped = WrappedHungerEvent(event)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectRegenMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectRegenMultiplier.kt
@@ -25,9 +25,8 @@ class EffectRegenMultiplier : Effect("regen_multiplier") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("multiplier", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("multiplier", player) }
         )
         modifiers[player.uniqueId] = registeredModifiers
     }
@@ -57,7 +56,7 @@ class EffectRegenMultiplier : Effect("regen_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (modifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         val wrapped = WrappedRegenEvent(event)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectSellMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectSellMultiplier.kt
@@ -28,9 +28,8 @@ class EffectSellMultiplier : Effect("sell_multiplier") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("multiplier", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("multiplier", player) }
         )
         modifiers[player.uniqueId] = registeredModifiers
     }
@@ -49,7 +48,7 @@ class EffectSellMultiplier : Effect("sell_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (modifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         return multiplier

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectXpMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectXpMultiplier.kt
@@ -26,9 +26,8 @@ class EffectXpMultiplier : Effect("xp_multiplier") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("multiplier", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("multiplier", player) }
         )
         modifiers[player.uniqueId] = registeredModifiers
     }
@@ -54,7 +53,7 @@ class EffectXpMultiplier : Effect("xp_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (modifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         val wrapped = WrappedXpEvent(event.expChangeEvent)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/aureliumskills/EffectSkillXpMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/aureliumskills/EffectSkillXpMultiplier.kt
@@ -31,9 +31,8 @@ class EffectSkillXpMultiplier : Effect("skill_xp_multiplier") {
                 registeredModifiers.removeIf { it.uuid == uuid }
                 registeredModifiers.add(
                     MultiplierModifier(
-                        uuid,
-                        config.getDoubleFromExpression("multiplier", player)
-                    )
+                        uuid
+                    ) { config.getDoubleFromExpression("multiplier", player) }
                 )
                 skillModifiers[skill] = registeredModifiers
                 modifiers[player.uniqueId] = skillModifiers
@@ -44,9 +43,8 @@ class EffectSkillXpMultiplier : Effect("skill_xp_multiplier") {
             registeredModifiers.removeIf { it.uuid == uuid }
             registeredModifiers.add(
                 MultiplierModifier(
-                    uuid,
-                    config.getDoubleFromExpression("multiplier", player)
-                )
+                    uuid
+                ) { config.getDoubleFromExpression("multiplier", player) }
             )
             globalModifiers[player.uniqueId] = registeredModifiers
         }
@@ -82,12 +80,12 @@ class EffectSkillXpMultiplier : Effect("skill_xp_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
 
         for (modifier in (modifiers[player.uniqueId]?.get(event.skill) ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         event.amount *= multiplier

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecobosses/EffectBossDropChanceMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecobosses/EffectBossDropChanceMultiplier.kt
@@ -30,9 +30,8 @@ class EffectBossDropChanceMultiplier : Effect("boss_drop_chance_multiplier") {
                 registeredModifiers.removeIf { it.uuid == uuid }
                 registeredModifiers.add(
                     MultiplierModifier(
-                        uuid,
-                        config.getDoubleFromExpression("multiplier", player)
-                    )
+                        uuid
+                    ) { config.getDoubleFromExpression("multiplier", player) }
                 )
                 bossMultipliers[boss] = registeredModifiers
                 modifiers[player.uniqueId] = bossMultipliers
@@ -43,9 +42,8 @@ class EffectBossDropChanceMultiplier : Effect("boss_drop_chance_multiplier") {
             registeredModifiers.removeIf { it.uuid == uuid }
             registeredModifiers.add(
                 MultiplierModifier(
-                    uuid,
-                    config.getDoubleFromExpression("multiplier", player)
-                )
+                    uuid
+                ) { config.getDoubleFromExpression("multiplier", player) }
             )
             globalModifiers[player.uniqueId] = registeredModifiers
         }
@@ -81,11 +79,11 @@ class EffectBossDropChanceMultiplier : Effect("boss_drop_chance_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         for (modifier in (modifiers[player.uniqueId]?.get(event.boss.id) ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         event.chance *= multiplier

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecojobs/EffectJobXpMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecojobs/EffectJobXpMultiplier.kt
@@ -31,9 +31,8 @@ class EffectJobXpMultiplier : Effect("job_xp_multiplier") {
                 registeredModifiers.removeIf { it.uuid == uuid }
                 registeredModifiers.add(
                     MultiplierModifier(
-                        uuid,
-                        config.getDoubleFromExpression("multiplier", player)
-                    )
+                        uuid
+                    ) { config.getDoubleFromExpression("multiplier", player) }
                 )
                 jobModifiers[job] = registeredModifiers
                 modifiers[player.uniqueId] = jobModifiers
@@ -44,9 +43,8 @@ class EffectJobXpMultiplier : Effect("job_xp_multiplier") {
             registeredModifiers.removeIf { it.uuid == uuid }
             registeredModifiers.add(
                 MultiplierModifier(
-                    uuid,
-                    config.getDoubleFromExpression("multiplier", player)
-                )
+                    uuid
+                ) { config.getDoubleFromExpression("multiplier", player) }
             )
             globalModifiers[player.uniqueId] = registeredModifiers
         }
@@ -84,12 +82,12 @@ class EffectJobXpMultiplier : Effect("job_xp_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
 
         for (modifier in (modifiers[player.uniqueId]?.get(event.job) ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         val wrapped = WrappedJobXpEvent(event)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecopets/EffectPetXpMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecopets/EffectPetXpMultiplier.kt
@@ -31,9 +31,8 @@ class EffectPetXpMultiplier : Effect("pet_xp_multiplier") {
                 registeredModifiers.removeIf { it.uuid == uuid }
                 registeredModifiers.add(
                     MultiplierModifier(
-                        uuid,
-                        config.getDoubleFromExpression("multiplier", player)
-                    )
+                        uuid
+                    ) { config.getDoubleFromExpression("multiplier", player) }
                 )
                 petModifiers[pet] = registeredModifiers
                 modifiers[player.uniqueId] = petModifiers
@@ -44,9 +43,8 @@ class EffectPetXpMultiplier : Effect("pet_xp_multiplier") {
             registeredModifiers.removeIf { it.uuid == uuid }
             registeredModifiers.add(
                 MultiplierModifier(
-                    uuid,
-                    config.getDoubleFromExpression("multiplier", player)
-                )
+                    uuid
+                ) { config.getDoubleFromExpression("multiplier", player) }
             )
             globalModifiers[player.uniqueId] = registeredModifiers
         }
@@ -84,12 +82,12 @@ class EffectPetXpMultiplier : Effect("pet_xp_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
 
         for (modifier in (modifiers[player.uniqueId]?.get(event.pet) ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         val wrapped = WrappedPetXpEvent(event)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecoskills/EffectSkillXpMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/ecoskills/EffectSkillXpMultiplier.kt
@@ -31,9 +31,8 @@ class EffectSkillXpMultiplier : Effect("skill_xp_multiplier") {
                 registeredModifiers.removeIf { it.uuid == uuid }
                 registeredModifiers.add(
                     MultiplierModifier(
-                        uuid,
-                        config.getDoubleFromExpression("multiplier", player)
-                    )
+                        uuid
+                    ) { config.getDoubleFromExpression("multiplier", player) }
                 )
                 skillModifiers[skill] = registeredModifiers
                 modifiers[player.uniqueId] = skillModifiers
@@ -44,9 +43,8 @@ class EffectSkillXpMultiplier : Effect("skill_xp_multiplier") {
             registeredModifiers.removeIf { it.uuid == uuid }
             registeredModifiers.add(
                 MultiplierModifier(
-                    uuid,
-                    config.getDoubleFromExpression("multiplier", player)
-                )
+                    uuid
+                ) { config.getDoubleFromExpression("multiplier", player) }
             )
             globalModifiers[player.uniqueId] = registeredModifiers
         }
@@ -84,12 +82,12 @@ class EffectSkillXpMultiplier : Effect("skill_xp_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
 
         for (modifier in (modifiers[player.uniqueId]?.get(event.skill) ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         val wrapped = WrappedSkillXpEvent(event)

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/jobs/EffectJobsMoneyMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/jobs/EffectJobsMoneyMultiplier.kt
@@ -25,9 +25,8 @@ class EffectJobsMoneyMultiplier : Effect("jobs_money_multiplier") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("multiplier", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("multiplier", player) }
         )
         globalModifiers[player.uniqueId] = registeredModifiers
     }
@@ -53,7 +52,7 @@ class EffectJobsMoneyMultiplier : Effect("jobs_money_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         var money = event.payment[CurrencyType.MONEY] ?: return

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/jobs/EffectJobsXpMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/jobs/EffectJobsXpMultiplier.kt
@@ -31,9 +31,8 @@ class EffectJobsXpMultiplier : Effect("jobs_xp_multiplier") {
                 registeredModifiers.removeIf { it.uuid == uuid }
                 registeredModifiers.add(
                     MultiplierModifier(
-                        uuid,
-                        config.getDoubleFromExpression("multiplier", player)
-                    )
+                        uuid
+                    ) { config.getDoubleFromExpression("multiplier", player) }
                 )
                 skillModifiers[job] = registeredModifiers
                 modifiers[player.uniqueId] = skillModifiers
@@ -44,9 +43,8 @@ class EffectJobsXpMultiplier : Effect("jobs_xp_multiplier") {
             registeredModifiers.removeIf { it.uuid == uuid }
             registeredModifiers.add(
                 MultiplierModifier(
-                    uuid,
-                    config.getDoubleFromExpression("multiplier", player)
-                )
+                    uuid
+                ) { config.getDoubleFromExpression("multiplier", player) }
             )
             globalModifiers[player.uniqueId] = registeredModifiers
         }
@@ -82,12 +80,12 @@ class EffectJobsXpMultiplier : Effect("jobs_xp_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
 
         for (modifier in (modifiers[player.uniqueId]?.get(event.job) ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         event.exp *= multiplier

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/mcmmo/EffectMcMMOXpMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/mcmmo/EffectMcMMOXpMultiplier.kt
@@ -31,9 +31,8 @@ class EffectMcMMOXpMultiplier : Effect("mcmmo_xp_multiplier") {
                 registeredModifiers.removeIf { it.uuid == uuid }
                 registeredModifiers.add(
                     MultiplierModifier(
-                        uuid,
-                        config.getDoubleFromExpression("multiplier", player)
-                    )
+                        uuid
+                    ) { config.getDoubleFromExpression("multiplier", player) }
                 )
                 skillModifiers[skill] = registeredModifiers
                 modifiers[player.uniqueId] = skillModifiers
@@ -44,9 +43,8 @@ class EffectMcMMOXpMultiplier : Effect("mcmmo_xp_multiplier") {
             registeredModifiers.removeIf { it.uuid == uuid }
             registeredModifiers.add(
                 MultiplierModifier(
-                    uuid,
-                    config.getDoubleFromExpression("multiplier", player)
-                )
+                    uuid
+                ) { config.getDoubleFromExpression("multiplier", player) }
             )
             globalModifiers[player.uniqueId] = registeredModifiers
         }
@@ -82,12 +80,12 @@ class EffectMcMMOXpMultiplier : Effect("mcmmo_xp_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (globalModifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
 
         for (modifier in (modifiers[player.uniqueId]?.get(event.skill) ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         event.rawXpGained = (event.rawXpGained * multiplier).toFloat()

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/paper/EffectElytraBoostSaveChance.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/paper/EffectElytraBoostSaveChance.kt
@@ -25,9 +25,8 @@ class EffectElytraBoostSaveChance : Effect("elytra_boost_save_chance") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("chance", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("chance", player) }
         )
         modifiers[player.uniqueId] = registeredModifiers
     }
@@ -53,7 +52,7 @@ class EffectElytraBoostSaveChance : Effect("elytra_boost_save_chance") {
         var chance = 100.0
 
         for (modifier in (modifiers[player.uniqueId] ?: emptyList())) {
-            chance *= (100 - modifier.multiplier)
+            chance *= (100 - modifier.multiplier())
         }
 
         if (NumberUtils.randFloat(0.0, 100.0) > chance) {

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/tmmobcoins/EffectMobCoinsMultiplier.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/integrations/tmmobcoins/EffectMobCoinsMultiplier.kt
@@ -24,9 +24,8 @@ class EffectMobCoinsMultiplier : Effect("mob_coins_multiplier") {
         registeredModifiers.removeIf { it.uuid == uuid }
         registeredModifiers.add(
             MultiplierModifier(
-                uuid,
-                config.getDoubleFromExpression("multiplier", player)
-            )
+                uuid
+            ) { config.getDoubleFromExpression("multiplier", player) }
         )
         modifiers[player.uniqueId] = registeredModifiers
     }
@@ -52,7 +51,7 @@ class EffectMobCoinsMultiplier : Effect("mob_coins_multiplier") {
         var multiplier = 1.0
 
         for (modifier in (modifiers[player.uniqueId] ?: emptyList())) {
-            multiplier *= modifier.multiplier
+            multiplier *= modifier.multiplier()
         }
 
         event.setDropAmount(event.obtainedAmount * multiplier)


### PR DESCRIPTION
In classes that export the Effect class, we have a handleEnable method.
In this method we are creating new MultiplierModifier with uuid, and modifier as Double.
Value of modifier is obtained from config.

The problem is that it is only obtained at the beginning. And the handle method uses the previously retrieved value.
If you set a dynamic value in config, like multiplier: "%level% * 2" the handleEnable method will be executed when the pet is created and when pet is lvl1, the multipler value in this example will be set to 2.
The problem arises when the pet's level is changed, for example it reaches level 2. The new multipler value in our example should be 4.
However, since the handleEnable method was done before, the MultiplierModifier still holds the old value.

Imo best solution to this problem would be to change to  MultiplierModifier to make it not store a static Double value but only a pointer to the config. Then the value would be taken in the handle method.