### PR TITLE
🐛 bug: made alt_click trigger ignore `Action.PHYSICAL`

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/triggers/TriggerAltClick.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/triggers/TriggerAltClick.kt
@@ -72,6 +72,10 @@ class TriggerAltClick : Trigger(
     fun handle(event: PlayerInteractEvent) {
         val player = event.player
         val itemStack = player.inventory.itemInMainHand
+        
+        if (event.action == Action.PHYSICAL) {
+            return
+        }
 
         if (LEFT_CLICK_ITEMS.contains(itemStack.type)) {
             if (event.action == Action.RIGHT_CLICK_AIR || event.action == Action.RIGHT_CLICK_BLOCK) {


### PR DESCRIPTION
Now alt_click trigger won't trigger if you activate a pressure plate or a tripwire hook, or when you step on a redstone ore or soil