### PR TITLE
Fixed keepInventory effect still drop players item.

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectKeepInventory.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectKeepInventory.kt
@@ -37,6 +37,7 @@ class EffectKeepInventory : Effect("keep_inventory") {
 
         if ((players[player.uniqueId] ?: emptyList()).isNotEmpty()) {
             event.keepInventory = true
+            event.drops.clear()
         }
     }
 


### PR DESCRIPTION
In world without keepInventory gamerule, players will still drop inventory items, but the inventory was not cleaned, so players will get double inventory items when they death, this PR is fixing this problem.