### PR TITLE
TriggerCraft returns repetitions on shift-click, fixes edge cases.

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/triggers/TriggerCraft.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/triggers/TriggerCraft.kt
@@ -8,7 +8,13 @@ import org.bukkit.entity.Player
 import org.bukkit.event.Event
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.CraftItemEvent
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.CraftingInventory;
+import org.bukkit.Material
 
 class TriggerCraft : Trigger(
     "craft", listOf(
@@ -26,16 +32,66 @@ class TriggerCraft : Trigger(
         if (event.result == Event.Result.DENY) {
             return
         }
+        
+        if(event.getAction() == InventoryAction.NOTHING || event.inventory.result == null) {
+            return
+        }
 
         val player = event.whoClicked as? Player ?: return
         val item = event.recipe.result
+        val cursor: ItemStack? = event.getCursor()
+        var recipeRepetitions = 1
+        val click = event.getClick()
 
+        if(click == ClickType.NUMBER_KEY) {
+            // Hotbar crafting fails if cursor contains item, or hotbar destination is not empty.
+            if ( cursor != null && cursor.type != Material.AIR)
+                recipeRepetitions = 0;
+            else if (player.inventory.getItem(event.getHotbarButton()) != null)
+                recipeRepetitions = 0
+        } else if(click == ClickType.DROP || click == ClickType.CONTROL_DROP) {
+            // Drop crafting with Q fails if cursor is full
+            if ( cursor != null && cursor.type != Material.AIR)
+                recipeRepetitions = 0
+        } else if(click == ClickType.SWAP_OFFHAND) {
+            // Can't craft into off-hand if off-hand is full.
+            if(player.inventory.itemInOffHand.type != Material.AIR)
+               recipeRepetitions = 0
+        } else if(click == ClickType.SHIFT_RIGHT || click == ClickType.SHIFT_LEFT) {
+                // This relies on the fact we can only craft as many as our smallest material stack.
+                recipeRepetitions = Integer.MAX_VALUE
+                for (istack: ItemStack? in event.inventory.matrix){
+                    if (istack != null && istack.amount < recipeRepetitions)
+                        recipeRepetitions = istack.amount
+                }
+                if(recipeRepetitions == Integer.MAX_VALUE)
+                    recipeRepetitions = 0;
+                else if(item.amount > 0) {
+                    // Determine how many of this stack we can fit in our inventory...
+                    var capacity = 0
+                    for (istack : ItemStack? in event.view.bottomInventory.storageContents) {
+                        if (istack == null)
+                            capacity += item.maxStackSize
+                        else if (istack.isSimilar(item))
+                            capacity += Math.max(item.maxStackSize - istack.amount, 0)
+                    }
+                    // If we can't fit everything, round up to the next full recipe amount.
+                    if (capacity < recipeRepetitions * item.amount)
+                        recipeRepetitions = ((capacity + item.amount - 1) / item.amount) 
+                }
+        }
+        
+        if(recipeRepetitions == 0){
+            return 
+        }
+        
         this.processTrigger(
             player,
             TriggerData(
                 player = player,
                 item = item
-            )
+            ),
+            recipeRepetitions.toDouble()
         )
     }
 }


### PR DESCRIPTION
Currently the "craft" trigger does not differentiate between crafting one item and an entire stack via shift-clicking. 

This meant that if an EcoSkills skill gains experience from crafting, for example, then players are rewarded by clicking to craft a recipe over and over, one result at a time, instead of shift-clicking to craft the whole stack... because shift-clicking still returned the 1.0 value.

I've modified TriggerCraft to return the number of repetitions of the recipe crafted. Spigot doesn't directly support this, so we have to check the player's inventory capacity to calculate the number that actually get crafted.

In the process of adding this feature, I also came across several edge cases where TriggerCraft would fire despite no item actually being crafted. Those loopholes would allow, say, a player to click a recipe over and over for experience gain despite it failing and never consuming the materials. Those loopholes are now closed.

As an aside, I'm new to Kotlin and to the repo as a whole, so I hope this meets the project's standards. Please let me know if there's a style guide or similar I should be conforming to, or if I'm doing something in a way that's not idiomatic Kotlin.