### PR TITLE
Add self_placed block filter

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/filters/Filters.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/filters/Filters.kt
@@ -16,6 +16,7 @@ import com.willfp.libreforge.filters.filters.FilterOnlyBosses
 import com.willfp.libreforge.filters.filters.FilterOnlyNonBosses
 import com.willfp.libreforge.filters.filters.FilterPlayerName
 import com.willfp.libreforge.filters.filters.FilterPlayerPlaced
+import com.willfp.libreforge.filters.filters.FilterSelfPlaced
 import com.willfp.libreforge.filters.filters.FilterPotionEffect
 import com.willfp.libreforge.filters.filters.FilterProjectiles
 import com.willfp.libreforge.filters.filters.FilterText
@@ -39,6 +40,7 @@ object Filters {
     val ABOVE_HEALTH_PERCENT: Filter = FilterAboveHealthPercent
     val FULLY_GROWN: Filter = FilterFullyGrown
     val PLAYER_PLACED: Filter = FilterPlayerPlaced
+    val SELF_PLACED: Filter = FilterSelfPlaced
     val TEXT: Filter = FilterText
     val TEXT_CONTAINS: Filter = FilterTextContains
     val IS_BEHIND_VICTIM: Filter = FilterIsBehindVictim

--- a/eco-api/src/main/kotlin/com/willfp/libreforge/filters/filters/FilterSelfPlaced.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/filters/filters/FilterSelfPlaced.kt
@@ -1,0 +1,17 @@
+package com.willfp.libreforge.filters.filters
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.util.isPlacedBy
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+
+object FilterSelfPlaced : Filter() {
+    override fun passes(data: TriggerData, config: Config): Boolean {
+        val block = data.block ?: return true
+        val player = data.player ?: return true
+
+        return config.withInverse("self_placed", Config::getBool) {
+            block.isPlacedBy(player) == it
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a filter to check if a given block was placed by the player themself, not just by any player. It functions using the same basic functionality as "player_placed".

### What good is a self_placed filter?

- A skill that levels up when breaking other player's stuff, but not your own.
- Weapons that deal bonus damage when standing on home turf.
- Tools that mine your own blocks instantly.
- Explosives that don't damage your own blocks
- Probably other uses too.

### How does it work?

The implementation relies on https://github.com/Auxilor/eco/pull/243 this pull request.
TL;DR -- eco currently stores an integer "1" for any block placed by a player. The actual value stored is never checked, just its existence. I've taken advantage of that to store a value identifying the placing player instead.