### PR TITLE
Update TriggerDamageItem.kt

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/triggers/TriggerDamageItem.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/triggers/triggers/TriggerDamageItem.kt
@@ -12,6 +12,7 @@ class TriggerDamageItem : Trigger(
     "damage_item", listOf(
         TriggerParameter.PLAYER,
         TriggerParameter.LOCATION,
+        TriggerParameter.EVENT,
         TriggerParameter.ITEM
     )
 ) {


### PR DESCRIPTION
Make damage_item actually cancellable.
Without this line, it will fail to load yml file, stating: "Specified effect does not support trigger damage_item".