### PR TITLE
Metadata is evil

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/PDCUtils.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/PDCUtils.kt
@@ -78,8 +78,8 @@ fun PersistentDataContainer.getPDC(key: NamespacedKey, save: Boolean = true): Pe
 }
 
 val Block.pdc : PersistentDataContainer get() {
-    return this.chunk.pdc.getPDC(NamespacedKey(plugin, "block:$x;$y;$z"))!!
+    return this.chunk.pdc.getPDC(NamespacedKey(plugin, "block/$x/$y/$z"))!!
 }
 fun Block.getPDCNoSave(): PersistentDataContainer? {
-    return this.chunk.pdc.getPDC(NamespacedKey(plugin, "block:$x;$y;$z"), false)
+    return this.chunk.pdc.getPDC(NamespacedKey(plugin, "block/$x/$y/$z"), false)
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/PDCUtils.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/PDCUtils.kt
@@ -1,0 +1,85 @@
+package com.willfp.libreforge
+
+import org.bukkit.NamespacedKey
+import org.bukkit.block.Block
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataHolder
+import org.bukkit.persistence.PersistentDataType
+import org.jetbrains.annotations.Contract
+import java.util.UUID
+
+val PersistentDataHolder.pdc get() = this.persistentDataContainer
+fun PersistentDataContainer.setBool(key: NamespacedKey, value: Boolean) {
+    this.set(key, PersistentDataType.BYTE, if (value) 1 else 0)
+}
+fun PersistentDataContainer.getBool(key: NamespacedKey, default: Boolean = false) : Boolean {
+    val value = get(key, PersistentDataType.BYTE) ?: return default
+    return value == 1.toByte()
+}
+fun PersistentDataContainer.hasBool(key: NamespacedKey): Boolean {
+    return has(key, PersistentDataType.BYTE)
+}
+fun PersistentDataContainer.setUUID(key: NamespacedKey, uuid: UUID) {
+    this.set(key, PersistentDataType.LONG_ARRAY, longArrayOf(uuid.leastSignificantBits, uuid.mostSignificantBits))
+}
+fun PersistentDataContainer.getUUID(key: NamespacedKey) : UUID? {
+    val arr = get(key, PersistentDataType.LONG_ARRAY) ?: return null
+    if (arr.size != 2) return null
+    return UUID(arr[1], arr[0])
+}
+fun PersistentDataContainer.hasUUID(key: NamespacedKey) : Boolean {
+    return has(key, PersistentDataType.LONG_ARRAY)
+}
+fun PersistentDataContainer.setDouble(key: NamespacedKey, double: Double) {
+    this.set(key, PersistentDataType.DOUBLE, double)
+}
+fun PersistentDataContainer.getDouble(key: NamespacedKey) : Double? {
+    return get(key, PersistentDataType.DOUBLE)
+}
+fun PersistentDataContainer.hasDouble(key: NamespacedKey) : Boolean {
+    return has(key, PersistentDataType.DOUBLE)
+}
+fun PersistentDataContainer.setFloat(key: NamespacedKey, float: Float) {
+    this.set(key, PersistentDataType.FLOAT, float)
+}
+fun PersistentDataContainer.getFloat(key: NamespacedKey) : Float? {
+    return get(key, PersistentDataType.FLOAT)
+}
+fun PersistentDataContainer.hasFloat(key: NamespacedKey) : Boolean {
+    return has(key, PersistentDataType.FLOAT)
+}
+fun PersistentDataContainer.setInt(key: NamespacedKey, int: Int) {
+    this.set(key, PersistentDataType.INTEGER, int)
+}
+fun PersistentDataContainer.getInt(key: NamespacedKey) : Int? {
+    return get(key, PersistentDataType.INTEGER)
+}
+fun PersistentDataContainer.hasInt(key: NamespacedKey) : Boolean {
+    return has(key, PersistentDataType.INTEGER)
+}
+fun PersistentDataContainer.setString(key: NamespacedKey, string: String) {
+    this.set(key, PersistentDataType.STRING, string)
+}
+fun PersistentDataContainer.getString(key: NamespacedKey) : String? {
+    return get(key, PersistentDataType.STRING)
+}
+fun PersistentDataContainer.hasString(key: NamespacedKey) : Boolean {
+    return has(key, PersistentDataType.STRING)
+}
+
+@Contract("_,true->!null")
+fun PersistentDataContainer.getPDC(key: NamespacedKey, save: Boolean = true): PersistentDataContainer? {
+    var pdc = get(key, PersistentDataType.TAG_CONTAINER)
+    if (pdc == null && save) {
+        pdc = this.adapterContext.newPersistentDataContainer()
+        set(key, PersistentDataType.TAG_CONTAINER, pdc)
+    }
+    return pdc
+}
+
+val Block.pdc : PersistentDataContainer get() {
+    return this.chunk.pdc.getPDC(NamespacedKey(plugin, "block:$x;$y;$z"))!!
+}
+fun Block.getPDCNoSave(): PersistentDataContainer? {
+    return this.chunk.pdc.getPDC(NamespacedKey(plugin, "block:$x;$y;$z"), false)
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/TriggerPlaceholderListener.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/TriggerPlaceholderListener.kt
@@ -10,7 +10,6 @@ import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-import java.util.UUID
 
 object TriggerPlaceholderListener : Listener {
 
@@ -81,10 +80,9 @@ object TriggerPlaceholderListener : Listener {
         val player = event.trigger.data.player ?: return
         val entity = event.trigger.data.victim ?: return
 
-        @Suppress("UNCHECKED_CAST")
         val hits =
             if (entity.health >= entity.getAttribute(Attribute.GENERIC_MAX_HEALTH)!!.value) {
-                0
+                1
             } else {
                 entity.getHits(player)
             }

--- a/core/src/main/kotlin/com/willfp/libreforge/TriggerPlaceholderListener.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/TriggerPlaceholderListener.kt
@@ -87,10 +87,10 @@ object TriggerPlaceholderListener : Listener {
                 entity.getHits(player)
             }
 
-        entity.pdc.setInt(NamespacedKey(plugin, "HITS:${player.uniqueId}"), hits)
+        entity.pdc.setInt(NamespacedKey(plugin, "HITS/${player.uniqueId}"), hits)
     }
 
     private fun LivingEntity.getHits(player: Player): Int {
-        return this.pdc.getInt(NamespacedKey(plugin, "HITS:${player.uniqueId}")) ?: 0
+        return this.pdc.getInt(NamespacedKey(plugin, "HITS/${player.uniqueId}")) ?: 0
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDamageNearbyEntities.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDamageNearbyEntities.kt
@@ -3,19 +3,19 @@ package com.willfp.libreforge.effects.impl
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.entities.Entities
 import com.willfp.eco.core.entities.TestableEntity
-import com.willfp.libreforge.ViolationContext
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.Effect
-import com.willfp.libreforge.getDoubleFromExpression
 import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.NamespacedKey
 import org.bukkit.entity.LivingEntity
 
 object EffectDamageNearbyEntities : Effect<Collection<TestableEntity>>("damage_nearby_entities") {
     override val parameters = setOf(
         TriggerParameter.LOCATION, TriggerParameter.PLAYER
     )
+    private val ignoreNearbyDamage = NamespacedKey(plugin, "ignore-nearby-damage")
 
     override val arguments = arguments {
         require("radius", "You must specify the radius!")
@@ -34,7 +34,7 @@ object EffectDamageNearbyEntities : Effect<Collection<TestableEntity>>("damage_n
         val damageSelf = config.getBoolOrNull("damage_self") ?: true
 
         for (entity in world.getNearbyEntities(location, radius, radius, radius)) {
-            if (entity.hasMetadata("ignore-nearby-damage")) {
+            if (entity.pdc.hasBool(ignoreNearbyDamage)) {
                 continue
             }
 
@@ -48,8 +48,8 @@ object EffectDamageNearbyEntities : Effect<Collection<TestableEntity>>("damage_n
                 }
             }
 
-            entity.setMetadata("ignore-nearby-damage", plugin.metadataValueFactory.create(true))
-            plugin.scheduler.runLater(5) { entity.removeMetadata("ignore-nearby-damage", plugin) }
+            entity.pdc.setBool(ignoreNearbyDamage, true)
+            plugin.scheduler.runLater(5) { entity.pdc.remove(ignoreNearbyDamage) }
 
             if (!damageSelf && (entity == player)) {
                 continue

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectIgnite.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectIgnite.kt
@@ -1,14 +1,12 @@
 package com.willfp.libreforge.effects.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.NoCompileData
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.Effect
-import com.willfp.libreforge.getDoubleFromExpression
-import com.willfp.libreforge.getIntFromExpression
 import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.NamespacedKey
 import org.bukkit.event.EventHandler
 import org.bukkit.event.entity.EntityDamageEvent
 
@@ -17,6 +15,7 @@ object EffectIgnite : Effect<NoCompileData>("ignite") {
         TriggerParameter.VICTIM,
         TriggerParameter.PLAYER
     )
+    private val ignite = NamespacedKey(plugin, "libreforge-ignite")
 
     override val arguments = arguments {
         require("damage_per_tick", "You must specify the damage per fire tick!")
@@ -29,7 +28,7 @@ object EffectIgnite : Effect<NoCompileData>("ignite") {
         val duration = config.getIntFromExpression("ticks", data)
 
         victim.fireTicks = duration
-        victim.setMetadata("libreforge-ignite", plugin.createMetadataValue(damage))
+        victim.pdc.setDouble(ignite, damage)
 
         return true
     }
@@ -39,10 +38,6 @@ object EffectIgnite : Effect<NoCompileData>("ignite") {
         if (event.cause != EntityDamageEvent.DamageCause.FIRE_TICK) {
             return
         }
-        if (!event.entity.hasMetadata("libreforge-ignite")) {
-            return
-        }
-
-        event.damage = event.entity.getMetadata("libreforge-ignite")[0].asDouble()
+        event.damage = event.entity.pdc.getDouble(ignite) ?: return
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectTraceback.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectTraceback.kt
@@ -1,15 +1,20 @@
 package com.willfp.libreforge.effects.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.NoCompileData
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.Effect
-import com.willfp.libreforge.getDoubleFromExpression
 import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.NamespacedKey
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+import java.util.stream.Collector
+import java.util.stream.Collectors
+import java.util.stream.Stream
 
 object EffectTraceback : Effect<NoCompileData>("traceback") {
     override val parameters = setOf(
@@ -20,15 +25,14 @@ object EffectTraceback : Effect<NoCompileData>("traceback") {
         require("seconds", "You must specify the amount of seconds to go back in time (1-30)!")
     }
 
-    private val key = "libreforge_traceback"
+    private val key = NamespacedKey(plugin, "libreforge_traceback")
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
         val player = data.player ?: return false
 
         val time = config.getDoubleFromExpression("seconds", data).toInt().coerceIn(1..30)
 
-        @Suppress("UNCHECKED_CAST")
-        val times = player.getMetadata(key).getOrNull(0)?.value() as? List<Location> ?: emptyList()
+        val times = player.pdc.get(key, Times)?: emptyList()
 
         // Most recent is last
         val index = times.size - time
@@ -43,13 +47,55 @@ object EffectTraceback : Effect<NoCompileData>("traceback") {
     override fun postRegister() {
         plugin.scheduler.runTimer(20, 20) {
             for (player in Bukkit.getOnlinePlayers()) {
-                @Suppress("UNCHECKED_CAST")
-                val times = player.getMetadata(key).getOrNull(0)?.value() as? List<Location> ?: emptyList()
+                val times = player.pdc.get(key, Times) ?: emptyList()
                 val newTimes = (if (times.size < 29) times else times.drop(1)) + player.location
 
-                player.removeMetadata(key, plugin)
-                player.setMetadata(key, plugin.metadataValueFactory.create(newTimes))
+                player.pdc.set(key, Times, newTimes)
             }
         }
+    }
+
+    private object Times : PersistentDataType<Array<PersistentDataContainer>, List<Location>> {
+        override fun getPrimitiveType() = Array<PersistentDataContainer> ::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun getComplexType() = List::class.java as Class<List<Location>>
+        private val x = NamespacedKey(plugin, "x")
+        private val y = NamespacedKey(plugin, "y")
+        private val z = NamespacedKey(plugin, "z")
+        private val yaw = NamespacedKey(plugin, "yaw")
+        private val pitch = NamespacedKey(plugin, "pitch")
+        private val world = NamespacedKey(plugin, "world")
+        override fun fromPrimitive(
+            primitive: Array<PersistentDataContainer>,
+            context: PersistentDataAdapterContext
+        ): List<Location> = Stream.of(*primitive)
+            .map {
+                val world = it.getString(world)
+                Location(
+                    if (world == null) null else Bukkit.getWorld(world),
+                    it.getDouble(x)!!,
+                    it.getDouble(y)!!,
+                    it.getDouble(z)!!,
+                    it.getFloat(yaw)!!,
+                    it.getFloat(pitch)!!
+                )
+            }.toList()
+
+        override fun toPrimitive(
+            complex: List<Location>,
+            context: PersistentDataAdapterContext
+        ): Array<PersistentDataContainer> = complex.stream()
+            .map {
+                val pdc = context.newPersistentDataContainer()
+                if (it.world != null) pdc.setString(world, it.world.name)
+                pdc.setDouble(x, it.x)
+                pdc.setDouble(y, it.y)
+                pdc.setDouble(z, it.z)
+                pdc.setFloat(yaw, it.yaw)
+                pdc.setFloat(pitch, it.pitch)
+                pdc
+            }.toList().toTypedArray()
+
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/templates/MineBlockEffect.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/templates/MineBlockEffect.kt
@@ -2,10 +2,12 @@ package com.willfp.libreforge.effects.templates
 
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.util.runExempted
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.NamespacedKey
 import org.bukkit.block.Block
 import org.bukkit.entity.Player
 
@@ -13,18 +15,19 @@ abstract class MineBlockEffect<T : Any>(id: String) : Effect<T>(id) {
     override val parameters = setOf(
         TriggerParameter.PLAYER
     )
+    private val ignore = NamespacedKey(plugin, "block-ignore")
 
     override fun shouldTrigger(config: Config, data: TriggerData, compileData: T): Boolean {
         val block = data.block ?: data.location?.block ?: return false
-        return !block.hasMetadata("block-ignore")
+        return block.getPDCNoSave()?.hasBool(ignore) != true
     }
 
     protected fun Player.breakBlocksSafely(blocks: Collection<Block>) {
         this.runExempted {
             for (block in blocks) {
-                block.setMetadata("block-ignore", plugin.createMetadataValue(true))
+                block.pdc.setBool(ignore, true)
                 this.breakBlock(block)
-                block.removeMetadata("block-ignore", plugin)
+                block.pdc.remove(ignore)
             }
         }
     }


### PR DESCRIPTION
fix https://github.com/Auxilor/libreforge/issues/95

Metadata can easily be used to have a memory leak, because it's never unloaded from RAM, pdc is saved in entity's nbt, and unloaded with the entity, so can't have a memory leak

Needs a bit more testing before coming from draft