### PR TITLE
Optimization and some fixes

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
@@ -41,6 +41,9 @@ class ItemRefreshListener(
     @EventHandler
     fun onChangeSlot(event: PlayerItemHeldEvent) {
         event.player.refreshHolders()
+        plugin.scheduler.run {
+            event.player.refreshHolders()
+        }
     }
 
     @EventHandler

--- a/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
@@ -41,9 +41,6 @@ class ItemRefreshListener(
     @EventHandler
     fun onChangeSlot(event: PlayerItemHeldEvent) {
         event.player.refreshHolders()
-        plugin.scheduler.run {
-            event.player.refreshHolders()
-        }
     }
 
     @EventHandler

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/ElementLike.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/ElementLike.kt
@@ -53,20 +53,28 @@ abstract class ElementLike : ConfigurableElement {
 
         // It would be nice to abstract repeat/delay away here, but that would be
         // really, really, overengineering it - even for me.
-        val repeatTimes = config.getIntFromExpression("repeat.times", trigger.data).coerceAtLeast(1)
-        val repeatStart = config.getDoubleFromExpression("repeat.start", trigger.data)
-        val repeatIncrement = config.getDoubleFromExpression("repeat.increment", trigger.data)
-        var repeatCount = repeatStart
+        var repeatTimes = 1
+        var repeatIncrement = 0.0
+        var repeatCount = 0.0
+        if (config.has("repeat")) {
+            repeatTimes = config.getIntFromExpression("repeat.times", trigger.data).coerceAtLeast(1)
+            val repeatStart = config.getDoubleFromExpression("repeat.start", trigger.data)
+            repeatIncrement = config.getDoubleFromExpression("repeat.increment", trigger.data)
+            repeatCount = repeatStart
 
-        trigger.addPlaceholder(NamedValue("repeat_times", repeatTimes))
-        trigger.addPlaceholder(NamedValue("repeat_start", repeatStart))
-        trigger.addPlaceholder(NamedValue("repeat_increment", repeatIncrement))
-        trigger.addPlaceholder(DynamicNumericValue("repeat_count") { repeatCount })
+            trigger.addPlaceholder(NamedValue("repeat_times", repeatTimes))
+            trigger.addPlaceholder(NamedValue("repeat_start", repeatStart))
+            trigger.addPlaceholder(NamedValue("repeat_increment", repeatIncrement))
+            trigger.addPlaceholder(DynamicNumericValue("repeat_count") { repeatCount })
+        }
 
-        val delay = config.getIntFromExpression("delay", trigger.data)
-            .coerceAtLeast(0)
-            .let { if (!supportsDelay) 0 else it }
-            .toLong()
+        var delay = 0L
+        if (config.has("delay")) {
+            delay = config.getIntFromExpression("delay", trigger.data)
+                .coerceAtLeast(0)
+                .let { if (!supportsDelay) 0 else it }
+                .toLong()
+        }
 
         // Initial injection into mutators
         mutators.map { it.config }.forEach { it.addInjectablePlaceholder(trigger.placeholders) }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/ElementLike.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/ElementLike.kt
@@ -47,16 +47,16 @@ abstract class ElementLike : ConfigurableElement {
             return doTrigger(trigger)
         }
 
-        // Extra initial injection, otherwise it's not possible to use injections
-        // in the repeat configs.
-        config.addInjectablePlaceholder(trigger.placeholders)
-
         // It would be nice to abstract repeat/delay away here, but that would be
         // really, really, overengineering it - even for me.
         var repeatTimes = 1
         var repeatIncrement = 0.0
         var repeatCount = 0.0
         if (config.has("repeat")) {
+            // Extra initial injection, otherwise it's not possible to use injections
+            // in the repeat configs.
+            config.addInjectablePlaceholder(trigger.placeholders)
+
             repeatTimes = config.getIntFromExpression("repeat.times", trigger.data).coerceAtLeast(1)
             val repeatStart = config.getDoubleFromExpression("repeat.start", trigger.data)
             repeatIncrement = config.getDoubleFromExpression("repeat.increment", trigger.data)

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/arguments/impl/ArgumentEvery.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/arguments/impl/ArgumentEvery.kt
@@ -12,7 +12,7 @@ object ArgumentEvery: EffectArgument<NoCompileData>("every") {
     private val everyHandler = nestedMap<UUID, UUID, Int>()
 
     override fun isMet(element: ConfigurableElement, trigger: DispatchedTrigger, compileData: NoCompileData): Boolean {
-        val current = everyHandler[element.uuid][trigger.player.uniqueId] ?: 0
+        val current = everyHandler[element.uuid][trigger.player.uniqueId] ?: 1
 
         return current == 0
     }
@@ -28,7 +28,7 @@ object ArgumentEvery: EffectArgument<NoCompileData>("every") {
     private fun increment(element: ConfigurableElement, trigger: DispatchedTrigger) {
         val every = element.config.getIntFromExpression("every", trigger.data)
 
-        var current = everyHandler[element.uuid][trigger.player.uniqueId] ?: 0
+        var current = everyHandler[element.uuid][trigger.player.uniqueId] ?: 1
 
         current++
 


### PR DESCRIPTION
- calculate repeat and delay args only if needed to save some cpu time
   tests (/spark profiler --timeout 30):
   spark without commit: https://spark.lucko.me/8ZjnqIXmD1 (2464 ms) 
   spark with commit applied: https://spark.lucko.me/T5mz0tTQ8F (1544 ms)
- fix every argument to not return true on first check