### PR TITLE
FIX: Now when reloading the plugin, timers will not be duplicated.

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerGroupStatic.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerGroupStatic.kt
@@ -12,15 +12,19 @@ import org.bukkit.entity.Player
 object TriggerGroupStatic : TriggerGroup("static") {
     private val registry = mutableMapOf<Int, TriggerStatic>()
     private var tick = 0
+    private var createdTimer = false
 
     override fun create(value: String): Trigger? {
         val interval = value.toIntOrNull() ?: return null
         val trigger = TriggerStatic(interval)
         registry[interval] = trigger
+        createdTimer = false
         return trigger
     }
 
     override fun postRegister() {
+        if(createdTimer) return
+
         plugin.scheduler.runTimer(1, 1) {
             tick++
 
@@ -32,6 +36,8 @@ object TriggerGroupStatic : TriggerGroup("static") {
                 }
             }
         }
+
+        createdTimer = true
     }
 
     private class TriggerStatic(interval: Int) : Trigger("static_$interval") {


### PR DESCRIPTION
Previous behaviour:
When `/libreforge reload` was used on the server, multiple timers were created and effects would trigger more times then intended.

New behaviour:
A single timer is only created on the plugin's initialization.