### PR TITLE
Parse placeholders in value for `placeholder_equals` and `placeholder_contains` conditions.

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderContains.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderContains.kt
@@ -14,6 +14,7 @@ object ConditionPlaceholderContains : Condition<NoCompileData>("placeholder_cont
 
     override fun isMet(player: Player, config: Config, compileData: NoCompileData): Boolean {
         return config.getFormattedString("placeholder", placeholderContext(player = player))
-            .contains(config.getString("value"), ignoreCase = config.getBool("ignore_case"))
+            .contains(config.getFormattedString("value", placeholderContext(player = player)),
+                ignoreCase = config.getBool("ignore_case"))
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderEquals.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderEquals.kt
@@ -16,6 +16,7 @@ object ConditionPlaceholderEquals : Condition<NoCompileData>("placeholder_equals
 
     override fun isMet(player: Player, config: Config, compileData: NoCompileData): Boolean {
         return config.getFormattedString("placeholder", placeholderContext(player = player))
-            .equals(config.getString("value"), ignoreCase = true)
+            .equals(config.getFormattedString("value", placeholderContext(player = player)),
+                ignoreCase = config.getBool("ignore_case"))
     }
 }


### PR DESCRIPTION
This also adds the "ignore_case" option for placeholder_equals to ensure consistency.