### PR TITLE
Scuffed fix for AOE

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAOE.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAOE.kt
@@ -10,8 +10,10 @@ import com.willfp.libreforge.effects.executors.impl.NormalExecutorFactory
 import com.willfp.libreforge.effects.impl.aoe.AOEBlock
 import com.willfp.libreforge.effects.impl.aoe.AOEShapes
 import com.willfp.libreforge.toFloat3
+import com.willfp.libreforge.triggers.DispatchedTrigger
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
+import com.willfp.libreforge.triggers.impl.TriggerBlank
 
 object EffectAOE : Effect<EffectAOE.AOEData>("aoe") {
     override val parameters = setOf(
@@ -36,7 +38,20 @@ object EffectAOE : Effect<EffectAOE.AOEData>("aoe") {
             player.location.world,
             data
         ).filter { it != player }) {
-            compileData.chain?.trigger(data.dispatch(player))
+            compileData.chain?.trigger(DispatchedTrigger(player, TriggerBlank, TriggerData(
+                player = data.player,
+                victim = entity,
+                block = data.block,
+                event = data.event,
+                location = data.location,
+                projectile = data.projectile,
+                velocity = data.velocity,
+                item = data.item,
+                text = data.text,
+                value = data.value,
+                _originalPlayer = data.player
+            )
+            ))
         }
 
         return true

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAOE.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAOE.kt
@@ -38,20 +38,7 @@ object EffectAOE : Effect<EffectAOE.AOEData>("aoe") {
             player.location.world,
             data
         ).filter { it != player }) {
-            compileData.chain?.trigger(DispatchedTrigger(player, TriggerBlank, TriggerData(
-                player = data.player,
-                victim = entity,
-                block = data.block,
-                event = data.event,
-                location = data.location,
-                projectile = data.projectile,
-                velocity = data.velocity,
-                item = data.item,
-                text = data.text,
-                value = data.value,
-                _originalPlayer = data.player
-            )
-            ))
+            compileData.chain?.trigger(data.copy(victim = entity).dispatch(player))
         }
 
         return true

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAgeCrop.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAgeCrop.kt
@@ -15,16 +15,15 @@ object EffectAgeCrop : Effect<NoCompileData>("age_crop") {
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
         val crop = data.block ?: data.location?.block ?: return false
-        val state = crop.state as? Ageable ?: return false
-
+        val state = crop.blockData as? Ageable ?: return false
         if (state.age == state.maximumAge) {
             return false
         }
-
         val age = if (config.has("age")) config.getIntFromExpression("age", data) else 1
 
         val newAge = (state.age + age).coerceAtMost(state.maximumAge)
         state.age = newAge
+        crop.blockData = state
 
         return true
     }


### PR DESCRIPTION
Currently AOE isn't working as it should.

the TriggerData being used to run is only getting the "victim" from the trigger, which there is only one from the triggers. Instead of getting the entity which is from the return list of the shapes.

This fixes it, but is kinda scuffed.