### PR TITLE
Add support for blocks in aoe effect

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAOE.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAOE.kt
@@ -1,6 +1,7 @@
 package com.willfp.libreforge.effects.impl
 
 import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.core.integrations.antigrief.AntigriefManager
 import com.willfp.libreforge.ViolationContext
 import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.Chain
@@ -10,10 +11,8 @@ import com.willfp.libreforge.effects.executors.impl.NormalExecutorFactory
 import com.willfp.libreforge.effects.impl.aoe.AOEBlock
 import com.willfp.libreforge.effects.impl.aoe.AOEShapes
 import com.willfp.libreforge.toFloat3
-import com.willfp.libreforge.triggers.DispatchedTrigger
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
-import com.willfp.libreforge.triggers.impl.TriggerBlank
 
 object EffectAOE : Effect<EffectAOE.AOEData>("aoe") {
     override val parameters = setOf(
@@ -39,6 +38,14 @@ object EffectAOE : Effect<EffectAOE.AOEData>("aoe") {
             data
         ).filter { it != player }) {
             compileData.chain?.trigger(data.copy(victim = entity).dispatch(player))
+        }
+        for (block in shape.getBlocks(
+            player.location.toFloat3(),
+            player.eyeLocation.direction.toFloat3(),
+            player.location.world,
+            data
+        ).filter { AntigriefManager.canBreakBlock(player, it) && AntigriefManager.canPlaceBlock(player, it) }) {
+            compileData.chain?.trigger(data.copy(block = block).dispatch(player))
         }
 
         return true

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/AOEBlock.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/AOEBlock.kt
@@ -5,6 +5,7 @@ import com.willfp.libreforge.Compiled
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
+import org.bukkit.block.Block
 import org.bukkit.entity.LivingEntity
 
 /**
@@ -22,5 +23,13 @@ class AOEBlock<T>(
         data: TriggerData
     ): Collection<LivingEntity> {
         return shape.getEntities(location, direction, world, config, data, compileData)
+    }
+    fun getBlocks(
+        location: Float3,
+        direction: Float3,
+        world: World,
+        data: TriggerData
+    ): Collection<Block> {
+        return shape.getBlocks(location, direction, world, config, data, compileData)
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/AOEShape.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/AOEShape.kt
@@ -5,6 +5,7 @@ import com.willfp.libreforge.Compilable
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
+import org.bukkit.block.Block
 import org.bukkit.entity.LivingEntity
 
 abstract class AOEShape<T>(
@@ -18,4 +19,12 @@ abstract class AOEShape<T>(
         data: TriggerData,
         compileData: T
     ): Collection<LivingEntity>
+    abstract fun getBlocks(
+        location: Float3,
+        direction: Float3,
+        world: World,
+        config: Config,
+        data: TriggerData,
+        compileData: T
+    ): Collection<Block>
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCircle.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCircle.kt
@@ -1,9 +1,11 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.*
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.plugin
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.toLocation
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCircle.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCircle.kt
@@ -1,15 +1,15 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.NoCompileData
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.getDoubleFromExpression
-import com.willfp.libreforge.toLocation
+import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
+import org.bukkit.block.Block
 import org.bukkit.entity.LivingEntity
+import kotlin.math.roundToInt
 
 object AOEShapeCircle: AOEShape<NoCompileData>("circle") {
     override val arguments = arguments {
@@ -28,5 +28,30 @@ object AOEShapeCircle: AOEShape<NoCompileData>("circle") {
 
         return location.toLocation(world).getNearbyEntities(radius, radius, radius)
             .filterIsInstance<LivingEntity>()
+    }
+
+    override fun getBlocks(
+        location: Float3,
+        direction: Float3,
+        world: World,
+        config: Config,
+        data: TriggerData,
+        compileData: NoCompileData
+    ): Collection<Block> {
+        val radius = config.getDoubleFromExpression("radius", data)
+        val blocks = arrayListOf<Block>()
+        val radiusInt = radius.roundToInt()
+
+        for (x in (-radiusInt..radiusInt)) {
+            for (y in (-radiusInt..radiusInt)) {
+                for (z in (-radiusInt..radiusInt)) {
+                    val block = world.getBlockAt(
+                        location.toLocation(world).clone().add(x.toDouble(), y.toDouble(), z.toDouble())
+                    )
+                    blocks.add(block)
+                }
+            }
+        }
+        return blocks.filter { !it.isEmpty }
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCone.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCone.kt
@@ -1,10 +1,15 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.*
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.angle
+import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.plugin
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.toFloat3
+import com.willfp.libreforge.toLocation
 import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.xz
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
 import org.bukkit.block.Block

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCone.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeCone.kt
@@ -1,19 +1,16 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.NoCompileData
-import com.willfp.libreforge.angle
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.getDoubleFromExpression
-import com.willfp.libreforge.toFloat3
-import com.willfp.libreforge.toLocation
+import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
-import com.willfp.libreforge.xz
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
+import org.bukkit.block.Block
 import org.bukkit.entity.LivingEntity
 import kotlin.math.abs
+import kotlin.math.roundToInt
 
 object AOEShapeCone: AOEShape<NoCompileData>("cone") {
     override val arguments = arguments {
@@ -47,5 +44,30 @@ object AOEShapeCone: AOEShape<NoCompileData>("cone") {
 
                 abs(angle) <= maxAngle / 2
             }
+    }
+    // todo: change this, copied from shape circle
+    override fun getBlocks(
+        location: Float3,
+        direction: Float3,
+        world: World,
+        config: Config,
+        data: TriggerData,
+        compileData: NoCompileData
+    ): Collection<Block> {
+        val radius = config.getDoubleFromExpression("radius", data)
+        val blocks = arrayListOf<Block>()
+        val radiusInt = radius.roundToInt()
+
+        for (x in (-radiusInt..radiusInt)) {
+            for (y in (-radiusInt..radiusInt)) {
+                for (z in (-radiusInt..radiusInt)) {
+                    val block = world.getBlockAt(
+                        location.toLocation(world).clone().add(x.toDouble(), y.toDouble(), z.toDouble())
+                    )
+                    blocks.add(block)
+                }
+            }
+        }
+        return blocks.filter { !it.isEmpty }
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeOffsetCircle.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeOffsetCircle.kt
@@ -1,9 +1,12 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.*
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.plugin
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.normalize
+import com.willfp.libreforge.toLocation
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
@@ -51,7 +54,6 @@ object AOEShapeOffsetCircle: AOEShape<NoCompileData>("offset_circle") {
                     val block = world.getBlockAt(
                         location.toLocation(world).clone().add(x.toDouble(), y.toDouble(), z.toDouble())
                     )
-                    plugin.logger.info("block being added: ${block.type.name}")
                     blocks.add(block)
                 }
             }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeOffsetCircle.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeOffsetCircle.kt
@@ -1,16 +1,15 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.NoCompileData
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.getDoubleFromExpression
-import com.willfp.libreforge.normalize
-import com.willfp.libreforge.toLocation
+import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
+import org.bukkit.block.Block
 import org.bukkit.entity.LivingEntity
+import kotlin.math.roundToInt
 
 object AOEShapeOffsetCircle: AOEShape<NoCompileData>("offset_circle") {
     override val arguments = arguments {
@@ -32,5 +31,31 @@ object AOEShapeOffsetCircle: AOEShape<NoCompileData>("offset_circle") {
         return (location + direction.normalize() * offset.toFloat())
             .toLocation(world)
             .getNearbyEntities(radius, radius, radius).filterIsInstance<LivingEntity>()
+    }
+    // todo: change this, copied from shape circle
+    override fun getBlocks(
+        location: Float3,
+        direction: Float3,
+        world: World,
+        config: Config,
+        data: TriggerData,
+        compileData: NoCompileData
+    ): Collection<Block> {
+        val radius = config.getDoubleFromExpression("radius", data)
+        val blocks = arrayListOf<Block>()
+        val radiusInt = radius.roundToInt()
+
+        for (x in (-radiusInt..radiusInt)) {
+            for (y in (-radiusInt..radiusInt)) {
+                for (z in (-radiusInt..radiusInt)) {
+                    val block = world.getBlockAt(
+                        location.toLocation(world).clone().add(x.toDouble(), y.toDouble(), z.toDouble())
+                    )
+                    plugin.logger.info("block being added: ${block.type.name}")
+                    blocks.add(block)
+                }
+            }
+        }
+        return blocks.filter { it.isEmpty }
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeScanInFront.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeScanInFront.kt
@@ -1,18 +1,15 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.NoCompileData
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.getDoubleFromExpression
-import com.willfp.libreforge.getIntFromExpression
-import com.willfp.libreforge.normalize
-import com.willfp.libreforge.plusAssign
-import com.willfp.libreforge.toLocation
+import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
+import org.bukkit.block.Block
 import org.bukkit.entity.LivingEntity
+import kotlin.math.roundToInt
 
 object AOEShapeScanInFront: AOEShape<NoCompileData>("scan_in_front") {
     override val arguments = arguments {
@@ -46,5 +43,31 @@ object AOEShapeScanInFront: AOEShape<NoCompileData>("scan_in_front") {
         }
 
         return emptyList()
+    }
+    // todo: change this, this is copied from shape circle
+    override fun getBlocks(
+        location: Float3,
+        direction: Float3,
+        world: World,
+        config: Config,
+        data: TriggerData,
+        compileData: NoCompileData
+    ): Collection<Block> {
+        val radius = config.getDoubleFromExpression("radius", data)
+        val blocks = arrayListOf<Block>()
+        val radiusInt = radius.roundToInt()
+
+        for (x in (-radiusInt..radiusInt)) {
+            for (y in (-radiusInt..radiusInt)) {
+                for (z in (-radiusInt..radiusInt)) {
+                    val block = world.getBlockAt(
+                        location.toLocation(world).clone().add(x.toDouble(), y.toDouble(), z.toDouble())
+                    )
+                    plugin.logger.info("block being added: ${block.type.name}")
+                    blocks.add(block)
+                }
+            }
+        }
+        return blocks.filter { !it.isEmpty }
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeScanInFront.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/aoe/impl/AOEShapeScanInFront.kt
@@ -1,9 +1,14 @@
 package com.willfp.libreforge.effects.impl.aoe.impl
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.libreforge.*
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.impl.aoe.AOEShape
-import com.willfp.libreforge.plugin
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.getIntFromExpression
+import com.willfp.libreforge.normalize
+import com.willfp.libreforge.plusAssign
+import com.willfp.libreforge.toLocation
 import com.willfp.libreforge.triggers.TriggerData
 import dev.romainguy.kotlin.math.Float3
 import org.bukkit.World
@@ -63,7 +68,6 @@ object AOEShapeScanInFront: AOEShape<NoCompileData>("scan_in_front") {
                     val block = world.getBlockAt(
                         location.toLocation(world).clone().add(x.toDouble(), y.toDouble(), z.toDouble())
                     )
-                    plugin.logger.info("block being added: ${block.type.name}")
                     blocks.add(block)
                 }
             }


### PR DESCRIPTION
!!! Not fully implemented

This adds support for blocks in AOE effects as well, so users are able to add effects affecting the blocks.
However this might be not how you would like it. So this is more of a draft.

Currently it only supports circle shape, I haven't added support for the other shapes yet.
I'm also not sure if this should be the same as `aoe` effect, or be separated into a different effect like `aoe_blocks` which could let users have more control for optimisation.