### PR TITLE
Add victim_movement_multiplier

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
@@ -384,5 +384,6 @@ object Effects : Registry<Effect<*>>() {
         register(EffectRapidBows)
         register(EffectNameEntity)
         register(EffectTotalDamageMultiplier)
+        register(EffectVictimMovementMultiplier)
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
@@ -385,5 +385,6 @@ object Effects : Registry<Effect<*>>() {
         register(EffectNameEntity)
         register(EffectTotalDamageMultiplier)
         register(EffectVictimMovementMultiplier)
+        register(EffectSetArmorTrim)
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetArmorTrim.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetArmorTrim.kt
@@ -1,0 +1,66 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.inventory.meta.ArmorMeta
+import org.bukkit.inventory.meta.trim.ArmorTrim
+import org.bukkit.inventory.meta.trim.TrimMaterial
+import org.bukkit.inventory.meta.trim.TrimPattern
+
+object EffectSetArmorTrim: Effect<NoCompileData>("set_armor_trim") {
+    override val parameters = setOf(
+        TriggerParameter.ITEM
+    )
+
+    override val arguments = arguments {
+        require("pattern", "You must specify the trim pattern!")
+        require("material", "You must specify the trim material!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val item = data.item ?: return false
+        val itemMeta = item.itemMeta ?: return false
+        val armorMeta = itemMeta as? ArmorMeta ?: return false
+
+        var pattern = TrimPattern.COAST
+        when (config.getString("pattern").lowercase()) {
+            "dune" -> pattern = TrimPattern.DUNE
+            "eye" -> pattern = TrimPattern.EYE
+            "host" -> pattern = TrimPattern.HOST
+            "raiser" -> pattern = TrimPattern.RAISER
+            "rib" -> pattern = TrimPattern.RIB
+            "sentry" -> pattern = TrimPattern.SENTRY
+            "shaper" -> pattern = TrimPattern.SHAPER
+            "silence" -> pattern = TrimPattern.SILENCE
+            "snout" -> pattern = TrimPattern.SNOUT
+            "spire" -> pattern = TrimPattern.SPIRE
+            "tide" -> pattern = TrimPattern.TIDE
+            "vex" -> pattern = TrimPattern.VEX
+            "ward" -> pattern = TrimPattern.WARD
+            "wayfinder" -> pattern = TrimPattern.WAYFINDER
+            "wild" -> pattern = TrimPattern.WILD
+        }
+        var material = TrimMaterial.AMETHYST
+        when (config.getString("material").lowercase()) {
+            "copper" -> material = TrimMaterial.COPPER
+            "diamond" -> material = TrimMaterial.DIAMOND
+            "emerald" -> material = TrimMaterial.EMERALD
+            "gold" -> material = TrimMaterial.GOLD
+            "iron" -> material = TrimMaterial.IRON
+            "lapis" -> material = TrimMaterial.LAPIS
+            "netherite" -> material = TrimMaterial.NETHERITE
+            "quartz" -> material = TrimMaterial.QUARTZ
+            "redstone" -> material = TrimMaterial.REDSTONE
+        }
+
+        val trim = ArmorTrim(material, pattern)
+        armorMeta.trim = trim
+        item.itemMeta = armorMeta
+
+        return true
+    }
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectVictimMovementMultiplier.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectVictimMovementMultiplier.kt
@@ -1,0 +1,36 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.plugin
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.attribute.Attribute
+
+object EffectVictimMovementMultiplier: Effect<NoCompileData>("victim_movement_multiplier") {
+    override val parameters = setOf(
+        TriggerParameter.VICTIM
+    )
+
+    override val arguments = arguments {
+        require("multiplier", "You must specify the multiplier!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val victim = data.victim ?: return false
+        val attribute = victim.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED) ?: return false
+        val attributeValue = attribute.value
+        val duration = if (config.has("duration")) config.getIntFromExpression("duration") else null
+
+        attribute.baseValue = attributeValue * config.getDoubleFromExpression("multiplier");
+        if (duration != null && duration > 0) {
+            plugin.scheduler.runLater(duration.toLong()) {
+                attribute.baseValue = attributeValue
+            }
+        }
+        return true
+    }
+
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectVictimMovementMultiplier.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectVictimMovementMultiplier.kt
@@ -29,8 +29,8 @@ object EffectVictimMovementMultiplier: Effect<NoCompileData>("victim_movement_mu
             return false
         }
         attribute.baseValue = attributeValue * config.getDoubleFromExpression("multiplier")
-        victim.setMetadata("libreforge-vms", plugin.createMetadataValue("1"))
         if (duration != null && duration > 0) {
+            victim.setMetadata("libreforge-vms", plugin.createMetadataValue("1"))
             plugin.scheduler.runLater(duration.toLong()) {
                 attribute.baseValue = attributeValue
                 victim.removeMetadata("libreforge-vms", plugin)

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectVictimMovementMultiplier.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectVictimMovementMultiplier.kt
@@ -8,6 +8,7 @@ import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.attribute.Attribute
+import org.bukkit.scheduler.BukkitTask
 
 object EffectVictimMovementMultiplier: Effect<NoCompileData>("victim_movement_multiplier") {
     override val parameters = setOf(
@@ -24,10 +25,15 @@ object EffectVictimMovementMultiplier: Effect<NoCompileData>("victim_movement_mu
         val attributeValue = attribute.value
         val duration = if (config.has("duration")) config.getIntFromExpression("duration") else null
 
-        attribute.baseValue = attributeValue * config.getDoubleFromExpression("multiplier");
+        if (victim.hasMetadata("libreforge-vms")) {
+            return false
+        }
+        attribute.baseValue = attributeValue * config.getDoubleFromExpression("multiplier")
+        victim.setMetadata("libreforge-vms", plugin.createMetadataValue("1"))
         if (duration != null && duration > 0) {
             plugin.scheduler.runLater(duration.toLong()) {
                 attribute.baseValue = attributeValue
+                victim.removeMetadata("libreforge-vms", plugin)
             }
         }
         return true


### PR DESCRIPTION
This apply to mobs and players, the movement_multiplier currently only apply to players.

example config might look like this:

```
effects:
  - id: victim_movement_multiplier
    args:
      multiplier: 0.5
      duration: 60 # optional, duration for the effect to last in ticks
    triggers:
      - melee_attack
```