### PR TITLE
Changes for shoot and shoot_arrow effects.

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
@@ -33,27 +33,25 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
 
         player.runExempted {
             val projectile = if (velocity == null || !config.getBool("inherit_velocity")) {
-                player.launchProjectile(projectileClass as Class<out Projectile>, player.velocity)
+                player.launchProjectile(projectileClass as Class<out Projectile>)
             } else {
                 player.launchProjectile(projectileClass as Class<out Projectile>, velocity)
             }
 
-            if (config.getBool("launch-at-location") && data.location != null) {
+            if (config.getBool("launch-at-location") && data.location != null && projectile !is AbstractArrow) {
                 projectile.teleportAsync(data.location)
             }
 
             if (projectile is AbstractArrow) {
                 projectile.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
                 projectile.pierceLevel = 1
-                if (config.getDoubleOrNull("damage") != null) {
-                    projectile.damage = config.getDoubleFromExpression("damage")
+                if (config.getDoubleOrNull("arrow_damage") != null) {
+                    projectile.damage = config.getDoubleFromExpression("arrow_damage")
                 }
                 else {
                     projectile.damage = 6.0
                 }
             }
-
-            projectile.setBounce(false)
 
             if (fire) {
                 projectile.fireTicks = Int.MAX_VALUE

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
@@ -7,12 +7,15 @@ import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.enumValueOfOrNull
+import com.willfp.libreforge.getIntFromExpression
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.AbstractArrow
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.Projectile
 import org.bukkit.event.entity.EntityShootBowEvent
+import org.bukkit.potion.PotionEffect
+import org.bukkit.potion.PotionEffectType
 
 @Suppress("UNCHECKED_CAST")
 object EffectShoot : Effect<NoCompileData>("shoot") {
@@ -34,7 +37,7 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
 
         player.runExempted {
             val projectile = if (velocity == null || !config.getBool("inherit_velocity")) {
-                player.launchProjectile(projectileClass as Class<out Projectile>)
+                player.launchProjectile(projectileClass as Class<out Projectile>, player.velocity)
             } else {
                 player.launchProjectile(projectileClass as Class<out Projectile>, velocity)
             }
@@ -45,6 +48,12 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
 
             if (projectile is AbstractArrow) {
                 projectile.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
+                if (config.getDoubleOrNull("damage") != null) {
+                    projectile.damage = config.getDoubleFromExpression("damage")
+                }
+                else {
+                    projectile.damage = 6.0
+                }
             }
 
             if (fire) {

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
@@ -1,21 +1,17 @@
 package com.willfp.libreforge.effects.impl
 
-import com.gamingmesh.jobs.commands.list.fire
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.util.runExempted
 import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.enumValueOfOrNull
-import com.willfp.libreforge.getIntFromExpression
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.AbstractArrow
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.Projectile
 import org.bukkit.event.entity.EntityShootBowEvent
-import org.bukkit.potion.PotionEffect
-import org.bukkit.potion.PotionEffectType
 
 @Suppress("UNCHECKED_CAST")
 object EffectShoot : Effect<NoCompileData>("shoot") {
@@ -48,6 +44,7 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
 
             if (projectile is AbstractArrow) {
                 projectile.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
+                projectile.pierceLevel = 1
                 if (config.getDoubleOrNull("damage") != null) {
                     projectile.damage = config.getDoubleFromExpression("damage")
                 }
@@ -55,6 +52,8 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
                     projectile.damage = 6.0
                 }
             }
+
+            projectile.setBounce(false)
 
             if (fire) {
                 projectile.fireTicks = Int.MAX_VALUE

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
@@ -45,7 +45,7 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
             if (projectile is AbstractArrow) {
                 projectile.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
                 projectile.pierceLevel = 1
-                if (config.getDoubleOrNull("arrow_damage") != null) {
+                if (config.getStringOrNull("arrow_damage") != null) {
                     projectile.damage = config.getDoubleFromExpression("arrow_damage")
                 }
                 else {

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
@@ -4,11 +4,14 @@ import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.util.runExempted
 import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getIntFromExpression
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.AbstractArrow
 import org.bukkit.entity.Arrow
 import org.bukkit.event.entity.EntityShootBowEvent
+import org.bukkit.potion.PotionEffect
+import org.bukkit.potion.PotionEffectType
 
 object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
     override val parameters = setOf(
@@ -22,7 +25,7 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
 
         player.runExempted {
             val arrow = if (velocity == null || !config.getBool("inherit_velocity")) {
-                player.launchProjectile(Arrow::class.java)
+                player.launchProjectile(Arrow::class.java, player.velocity)
             } else {
                 player.launchProjectile(Arrow::class.java, velocity)
             }
@@ -32,12 +35,34 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
             }
 
             arrow.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
+            arrow.pierceLevel = 1
+            if (config.getDoubleOrNull("damage") != null) {
+                arrow.damage = config.getDoubleFromExpression("damage")
+            }
+            else {
+                arrow.damage = 6.0
+            }
+
             if (fire) {
                 arrow.fireTicks = Int.MAX_VALUE
             }
 
             if (config.getBool("no_source")) {
                 arrow.shooter = null
+            }
+
+            if (config.getStringOrNull("effect") != null) {
+                arrow.addCustomEffect(
+                    PotionEffect(
+                    PotionEffectType.getByName(config.getString("effect").uppercase())
+                        ?: PotionEffectType.INCREASE_DAMAGE,
+                    config.getIntFromExpression("duration", data),
+                    config.getIntFromExpression("level", data) - 1,
+                    true,
+                    true,
+                    true
+                ), false
+                )
             }
         }
 

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
@@ -36,6 +36,7 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
 
             arrow.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
             arrow.pierceLevel = 1
+            arrow.setBounce(false)
             if (config.getDoubleOrNull("damage") != null) {
                 arrow.damage = config.getDoubleFromExpression("damage")
             }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
@@ -32,7 +32,7 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
 
             arrow.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
             arrow.pierceLevel = 1
-            if (config.getDoubleOrNull("arrow_damage") != null) {
+            if (config.getStringOrNull("arrow_damage") != null) {
                 arrow.damage = config.getDoubleFromExpression("arrow_damage")
             }
             else {

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
@@ -25,20 +25,15 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
 
         player.runExempted {
             val arrow = if (velocity == null || !config.getBool("inherit_velocity")) {
-                player.launchProjectile(Arrow::class.java, player.velocity)
+                player.launchProjectile(Arrow::class.java)
             } else {
                 player.launchProjectile(Arrow::class.java, velocity)
             }
 
-            if (config.getBool("launch-at-location") && data.location != null) {
-                arrow.teleportAsync(data.location)
-            }
-
             arrow.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
             arrow.pierceLevel = 1
-            arrow.setBounce(false)
-            if (config.getDoubleOrNull("damage") != null) {
-                arrow.damage = config.getDoubleFromExpression("damage")
+            if (config.getDoubleOrNull("arrow_damage") != null) {
+                arrow.damage = config.getDoubleFromExpression("arrow_damage")
             }
             else {
                 arrow.damage = 6.0


### PR DESCRIPTION
- Added arrow_damage arg for shoot (arrow only) and shoot_arrow effect.
- Added effect arg for shoot_arrow effect.
- Removed launch-at-location arg for shoot_arrow effect.
- launch-at-location arg won't work for arrow projectile in shoot effect.
- This is because in my test, this will lead arrow can not hit the entity.
 Picture for this is here, the arrows just spawn at zombie near location.:
<img width="365" alt="屏幕截图 2023-08-21 215843" src="https://github.com/Auxilor/libreforge/assets/35395058/8d906e8d-6760-4a74-a9d7-4aad06d6abe9">