### PR TITLE
expand hunger effects (add give_saturation, set_food, set_saturation) (respect-vanilla-limits for give_food + give_saturation)

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
@@ -406,5 +406,7 @@ object Effects : Registry<Effect<*>>() {
         register(EffectRemoveItemData)
         register(EffectAOEBlocks)
         register(EffectGiveSaturation)
+        register(EffectSetSaturation)
+        register(EffectSetFood)
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
@@ -405,5 +405,6 @@ object Effects : Registry<Effect<*>>() {
         register(EffectSetItemData)
         register(EffectRemoveItemData)
         register(EffectAOEBlocks)
+        register(EffectGiveSaturation)
     }
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveFood.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveFood.kt
@@ -19,7 +19,17 @@ object EffectGiveFood : Effect<NoCompileData>("give_food") {
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
         val player = data.player ?: return false
-        player.foodLevel = player.foodLevel + config.getIntFromExpression("amount", data)
+
+        if (config.getBool("respect-vanilla-limits")) {
+            if (player.foodLevel >= 20) { player.foodLevel = player.foodLevel } else
+            player.foodLevel = (player.foodLevel + config.getIntFromExpression("amount", data)).coerceIn(
+                minimumValue = 0,
+                maximumValue = 20
+            )
+        } else {
+            player.foodLevel = player.foodLevel + config.getIntFromExpression("amount", data)
+        }
+
 
         return true
     }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveFood.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveFood.kt
@@ -21,11 +21,12 @@ object EffectGiveFood : Effect<NoCompileData>("give_food") {
         val player = data.player ?: return false
 
         if (config.getBool("respect-vanilla-limits")) {
-            if (player.foodLevel >= 20) { player.foodLevel = player.foodLevel } else
+            if (player.foodLevel < 20) {
             player.foodLevel = (player.foodLevel + config.getIntFromExpression("amount", data)).coerceIn(
                 minimumValue = 0,
                 maximumValue = 20
-            )
+            )}
+            else return true
         } else {
             player.foodLevel = player.foodLevel + config.getIntFromExpression("amount", data)
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveSaturation.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveSaturation.kt
@@ -1,0 +1,26 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getIntFromExpression
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectGiveSaturation : Effect<NoCompileData>("give_saturation") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require("amount", "You must specify the amount of saturation to give!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        player.saturation = player.saturation + config.getIntFromExpression("amount", data)
+
+        return true
+    }
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveSaturation.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveSaturation.kt
@@ -20,13 +20,15 @@ object EffectGiveSaturation : Effect<NoCompileData>("give_saturation") {
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
         val player = data.player ?: return false
+        val maximumSaturation = (player.foodLevel.toFloat()).coerceAtMost(maximumValue = 20.0F)
 
         if (config.getBool("respect-vanilla-limits")) {
-            if (player.saturation >= 20.0F) { player.saturation = player.saturation } else
+            if (player.saturation < maximumSaturation) {
             player.saturation = (player.saturation + config.getIntFromExpression("amount", data)).coerceIn(
                 minimumValue = 0.0F,
-                maximumValue = (player.foodLevel.toFloat()).coerceAtMost(maximumValue = 20.0F)
-            )
+                maximumValue = maximumSaturation
+            )}
+            else return true
         } else {
             player.saturation = player.saturation + config.getIntFromExpression("amount", data)
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveSaturation.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveSaturation.kt
@@ -15,11 +15,23 @@ object EffectGiveSaturation : Effect<NoCompileData>("give_saturation") {
 
     override val arguments = arguments {
         require("amount", "You must specify the amount of saturation to give!")
+
     }
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
         val player = data.player ?: return false
-        player.saturation = player.saturation + config.getIntFromExpression("amount", data)
+
+        if (config.getBool("respect-vanilla-limits")) {
+            if (player.saturation >= 20.0F) { player.saturation = player.saturation } else
+            player.saturation = (player.saturation + config.getIntFromExpression("amount", data)).coerceIn(
+                minimumValue = 0.0F,
+                maximumValue = (player.foodLevel.toFloat()).coerceAtMost(maximumValue = 20.0F)
+            )
+        } else {
+            player.saturation = player.saturation + config.getIntFromExpression("amount", data)
+        }
+
+
 
         return true
     }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetFood.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetFood.kt
@@ -1,0 +1,26 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getIntFromExpression
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectSetFood : Effect<NoCompileData>("set_food") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require("amount", "You must specify the amount of food to set!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        player.foodLevel = config.getIntFromExpression("amount", data)
+
+        return true
+    }
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetSaturation.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetSaturation.kt
@@ -1,0 +1,26 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectSetSaturation : Effect<NoCompileData>("set_saturation") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require("amount", "You must specify the amount of saturation to set!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        player.saturation = config.getDoubleFromExpression("amount", data).toFloat()
+
+        return true
+    }
+}


### PR DESCRIPTION
Okay - this is take two (see #118) and I've confirmed it works in game.

I would love to build on this and add a system similar to how vanilla saturation works, where the max saturation you can receive is your current hunger/food value, but that's a little beyond my just-downloaded-inteliiJ-today skills.

```
 - id: give_saturation
    args:
      amount: 1 # The amount of saturation to give/take (allows negative values)
```