### PR TITLE
Changes for shoot and shoot_arrow effects. 

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
@@ -38,7 +38,7 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
                 player.launchProjectile(projectileClass as Class<out Projectile>, velocity)
             }
 
-            if (config.getBool("launch-at-location") && data.location != null) {
+            if (config.getBool("launch-at-location") && data.location != null && projectile !is AbstractArrow) {
                 projectile.teleportAsync(data.location)
             }
 

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
@@ -5,12 +5,15 @@ import com.willfp.eco.util.runExempted
 import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.getIntFromExpression
 import com.willfp.libreforge.getOrNull
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.AbstractArrow
 import org.bukkit.entity.Arrow
 import org.bukkit.event.entity.EntityShootBowEvent
+import org.bukkit.potion.PotionEffect
+import org.bukkit.potion.PotionEffectType
 
 object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
     override val parameters = setOf(
@@ -41,6 +44,20 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
 
             if (config.getBool("no_source")) {
                 arrow.shooter = null
+            }
+
+            if (config.getStringOrNull("effect") != null) {
+                arrow.addCustomEffect(
+                    PotionEffect(
+                        PotionEffectType.getByName(config.getString("effect").uppercase())
+                            ?: PotionEffectType.INCREASE_DAMAGE,
+                        config.getIntFromExpression("duration", data),
+                        config.getIntFromExpression("level", data) - 1,
+                        true,
+                        true,
+                        true
+                    ), false
+                )
             }
         }
 

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
@@ -4,6 +4,8 @@ import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.util.runExempted
 import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.getOrNull
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.AbstractArrow
@@ -27,8 +29,9 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
                 player.launchProjectile(Arrow::class.java, velocity)
             }
 
-            if (config.getBool("launch-at-location") && data.location != null) {
-                arrow.teleportAsync(data.location)
+            val damage = config.getOrNull("arrow_damage") { getDoubleFromExpression(it, data) }
+            if (damage != null) {
+                arrow.damage = damage
             }
 
             arrow.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED


### PR DESCRIPTION
- Added arrow_damage arg for shoot (arrow only) and shoot_arrow effect.
- Added effect arg for shoot_arrow effect.
- Removed launch-at-location arg for shoot_arrow effect.
- launch-at-location arg won't work for arrow projectile in shoot effect.
- This is because in my test, this will lead arrow can not hit the entity.
Picture for this is here, the arrows just spawn at zombie near location and the entity never be damaged:
![image](https://github.com/Auxilor/libreforge/assets/35395058/341f8edb-7a06-4314-94fa-f3ee9d46b06a)
