### PR TITLE
optimisation and fixes patch

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     }
     compileOnly("com.github.Zrips:Jobs:v4.17.2")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
-    compileOnly("com.github.ben-manes.caffeine:caffeine:3.0.5")
+    compileOnly("com.github.ben-manes.caffeine:caffeine:3.1.8")
     compileOnly("com.github.brcdev-minecraft:shopgui-api:2.2.0")
     compileOnly("com.github.Gypopo:EconomyShopGUI-API:1.1.0")
     compileOnly("com.github.N0RSKA:ScytherAPI:55a")

--- a/core/src/main/kotlin/com/willfp/libreforge/Holder.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/Holder.kt
@@ -153,9 +153,14 @@ open class SimpleProvidedHolder(
     override val holder: Holder
 ) : ProvidedHolder {
     override val provider = null
+    private val cachedHashCode = calculateHashCode()
+
+    private fun calculateHashCode(): Int {
+        return Objects.hash(holder)
+    }
 
     override fun hashCode(): Int {
-        return Objects.hash(holder)
+        return cachedHashCode
     }
 
     override fun equals(other: Any?): Boolean {
@@ -174,8 +179,14 @@ open class ItemProvidedHolder(
     override val holder: Holder,
     override val provider: ItemStack
 ) : ProvidedHolder {
-    override fun hashCode(): Int {
+    private val cachedHashCode = calculateHashCode()
+
+    private fun calculateHashCode(): Int {
         return Objects.hash(holder, provider)
+    }
+
+    override fun hashCode(): Int {
+        return cachedHashCode
     }
 
     override fun equals(other: Any?): Boolean {

--- a/core/src/main/kotlin/com/willfp/libreforge/HolderProvider.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/HolderProvider.kt
@@ -189,13 +189,17 @@ inline fun <reified T> registerSpecificRefreshFunction(crossinline function: (T)
     }
 }
 
+private val updateDelay = plugin.configYml.getInt("refresh.holders.update-delay").toLong()
+
 /**
  * Update holders, effects, and call refresh functions.
  */
 fun Dispatcher<*>.refreshHolders() {
     refreshFunctions.forEach { it(this) }
-    this.updateHolders()
-    this.updateEffects()
+    plugin.scheduler.runLater({ //run with delay for wait itemHolder update
+        this.updateHolders()
+        this.updateEffects()
+    }, updateDelay)
 }
 
 @Deprecated(

--- a/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
@@ -52,8 +52,18 @@ class ItemRefreshListener(
 
     @EventHandler(priority = EventPriority.LOWEST)
     fun onChangeSlot(event: PlayerItemHeldEvent) {
-        val dispatcher = event.player.toDispatcher()
-        dispatcher.refreshHolders()
+        val player = event.player
+
+        if (plugin.configYml.getBool("refresh.held.require-meta")) {
+            val oldItem = player.inventory.getItem(event.previousSlot)
+            val newItem = player.inventory.getItem(event.newSlot)
+            if ((oldItem?.hasItemMeta() == true) || (newItem?.hasItemMeta() == true)) {
+                return
+            }
+        }
+
+        val dispatcher = player.toDispatcher()
+
         plugin.scheduler.run {
             dispatcher.refreshHolders()
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
@@ -57,7 +57,7 @@ class ItemRefreshListener(
         if (plugin.configYml.getBool("refresh.held.require-meta")) {
             val oldItem = player.inventory.getItem(event.previousSlot)
             val newItem = player.inventory.getItem(event.newSlot)
-            if ((oldItem?.hasItemMeta() == true) || (newItem?.hasItemMeta() == true)) {
+            if (((oldItem == null) || !oldItem.hasItemMeta()) && ((newItem == null) || !newItem.hasItemMeta())) {
                 return
             }
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
@@ -4,6 +4,7 @@ import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.core.Prerequisite
 import com.willfp.eco.core.command.impl.PluginCommand
 import com.willfp.eco.core.integrations.IntegrationLoader
+import com.willfp.eco.core.integrations.afk.AFKManager
 import com.willfp.libreforge.commands.CommandLibreforge
 import com.willfp.libreforge.configs.ChainsYml
 import com.willfp.libreforge.configs.lrcdb.CommandLrcdb
@@ -118,8 +119,14 @@ class LibreforgeSpigotPlugin : EcoPlugin() {
         dispatchedTriggerFactory.startTicking()
 
         // Poll for changes
+        val skipAFKPlayers = configYml.getBool("refresh.players.skip-afk-players")
         plugin.scheduler.runTimer(20, 20) {
-            for (player in Bukkit.getOnlinePlayers()) {
+            val onlinePlayers = Bukkit.getOnlinePlayers().let { players ->
+                if (skipAFKPlayers) players.filter { !AFKManager.isAfk(it) }
+                else players
+            }
+
+            for (player in onlinePlayers) {
                 player.toDispatcher().refreshHolders()
             }
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/counters/bind/BoundCounters.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/counters/bind/BoundCounters.kt
@@ -15,9 +15,9 @@ internal object BoundCounters {
         bindings.remove(counter)
     }
 
-    fun values(): List<Counter> =
-        bindings.keys.toList()
+    fun values(): Set<Counter> =
+        bindings.keys
 
     val Counter.bindings: List<BoundCounter>
-        get() = BoundCounters.bindings[this].toList()
+        get() = BoundCounters.bindings[this]
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAddHolder.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAddHolder.kt
@@ -2,7 +2,6 @@ package com.willfp.libreforge.effects.impl
 
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.map.listMap
-import com.willfp.libreforge.GlobalDispatcher.uuid
 import com.willfp.libreforge.Holder
 import com.willfp.libreforge.HolderTemplate
 import com.willfp.libreforge.SimpleProvidedHolder
@@ -11,15 +10,11 @@ import com.willfp.libreforge.arguments
 import com.willfp.libreforge.conditions.Conditions
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.effects.Effects
-import com.willfp.libreforge.generatePlaceholders
 import com.willfp.libreforge.getIntFromExpression
-import com.willfp.libreforge.isType
 import com.willfp.libreforge.nest
 import com.willfp.libreforge.plugin
 import com.willfp.libreforge.registerGenericHolderProvider
 import com.willfp.libreforge.triggers.TriggerData
-import com.willfp.libreforge.triggers.TriggerParameter
-import org.bukkit.entity.Player
 import java.util.UUID
 
 object EffectAddHolder : Effect<HolderTemplate>("add_holder") {

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAddHolderInRadius.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAddHolderInRadius.kt
@@ -3,8 +3,6 @@ package com.willfp.libreforge.effects.impl
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.libreforge.Dispatcher
-import com.willfp.libreforge.EmptyProvidedHolder.holder
-import com.willfp.libreforge.GlobalDispatcher.location
 import com.willfp.libreforge.Holder
 import com.willfp.libreforge.HolderTemplate
 import com.willfp.libreforge.SimpleProvidedHolder
@@ -19,7 +17,6 @@ import com.willfp.libreforge.nest
 import com.willfp.libreforge.plugin
 import com.willfp.libreforge.registerGenericHolderProvider
 import com.willfp.libreforge.triggers.TriggerData
-import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.Location
 import java.util.Objects
 import java.util.UUID

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectRegenMultiplier.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectRegenMultiplier.kt
@@ -11,10 +11,10 @@ object EffectRegenMultiplier : MultiMultiplierEffect<RegainReason>("regen_multip
     override val key: String = "reason"
 
     override fun getElement(key: String): RegainReason? =
-        enumValueOfOrNull<RegainReason>("reason")
+        enumValueOfOrNull<RegainReason>(key.uppercase())
 
     override fun getAllElements(): Collection<RegainReason> =
-        RegainReason.values().toList()
+        RegainReason.entries
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityRegainHealthEvent) {

--- a/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnParticle.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnParticle.kt
@@ -2,11 +2,9 @@ package com.willfp.libreforge.effects.impl
 
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.particle.Particles
-import com.willfp.libreforge.NoCompileData
-import com.willfp.libreforge.arguments
+import com.willfp.libreforge.*
 import com.willfp.libreforge.effects.Effect
-import com.willfp.libreforge.getIntFromExpression
-import com.willfp.libreforge.getOrElse
+import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 
@@ -25,7 +23,9 @@ object EffectSpawnParticle : Effect<NoCompileData>(
         val location = data.location ?: return false
         val particle = Particles.lookup(config.getString("particle"))
         val amount = config.getOrElse("amount", 1) { getIntFromExpression(it, data) }
-        particle.spawn(location, amount)
+        plugin.scheduler.runAsync {
+            particle.spawn(location, amount)
+        }
 
         return true
     }

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/citizens/impl/TriggerLeftClickNPC.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/citizens/impl/TriggerLeftClickNPC.kt
@@ -15,6 +15,8 @@ object TriggerLeftClickNPC : Trigger("left_click_npc") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: NPCLeftClickEvent) {
+        if (!isEnabled) return
+
         val player = event.clicker ?: return
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/citizens/impl/TriggerRightClickNPC.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/citizens/impl/TriggerRightClickNPC.kt
@@ -15,6 +15,8 @@ object TriggerRightClickNPC : Trigger("right_click_npc") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: NPCRightClickEvent) {
+        if (!isEnabled) return
+
         val player = event.clicker ?: return
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/jobs/impl/TriggerJobsLevelUp.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/jobs/impl/TriggerJobsLevelUp.kt
@@ -15,6 +15,8 @@ object TriggerJobsLevelUp : Trigger("jobs_level_up") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: JobsLevelUpEvent) {
+        if (!isEnabled) return
+
         val player = event.player.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerBeaconEffect.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerBeaconEffect.kt
@@ -16,6 +16,8 @@ object TriggerBeaconEffect : Trigger("beacon_effect") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: BeaconEffectEvent) {
+        if (!isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerElytraBoost.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerElytraBoost.kt
@@ -15,6 +15,8 @@ object TriggerElytraBoost : Trigger("elytra_boost") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerElytraBoostEvent) {
+        if (!isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerSwing.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerSwing.kt
@@ -15,6 +15,8 @@ object TriggerSwing : Trigger("swing") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerArmSwingEvent) {
+        if (!isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerVillagerTrade.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/TriggerVillagerTrade.kt
@@ -16,6 +16,8 @@ object TriggerVillagerTrade : Trigger("villager_trade") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerTradeEvent) {
+        if (!isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/worldguard/impl/TriggerEnterRegion.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/worldguard/impl/TriggerEnterRegion.kt
@@ -21,6 +21,8 @@ object TriggerEnterRegion : Trigger("enter_region") {
 
     @EventHandler
     fun handle(event: PlayerMoveEvent) {
+        if (!isEnabled) return
+
         val player = event.player
 
         if (Prerequisite.HAS_PAPER.isMet && !event.hasChangedBlock()) {

--- a/core/src/main/kotlin/com/willfp/libreforge/slot/impl/SlotTypeAny.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/slot/impl/SlotTypeAny.kt
@@ -1,7 +1,6 @@
 package com.willfp.libreforge.slot.impl
 
 import com.willfp.eco.core.drops.DropQueue
-import com.willfp.eco.util.toSingletonList
 import com.willfp.libreforge.slot.SlotType
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
@@ -19,7 +18,7 @@ object SlotTypeAny : SlotType("any") {
 
     override fun getItems(entity: LivingEntity): List<ItemStack> {
         return if (entity is Player) {
-            entity.inventory.contents.toList().filterNotNull()
+            entity.inventory.contents.filterNotNull()
         } else {
             listOfNotNull(
                 entity.equipment?.helmet,

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/DispatchedTriggerFactory.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/DispatchedTriggerFactory.kt
@@ -28,9 +28,6 @@ class DispatchedTriggerFactory(
     }
 
     fun create(dispatcher: Dispatcher<*>, trigger: Trigger, data: TriggerData): DispatchedTrigger? {
-        if (!trigger.isEnabled) {
-            return null
-        }
 
         val hash = (trigger.hashCode() shl 5) xor data.hashCode()
         if (hash in dispatcherTriggers[dispatcher.uuid]) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerAltClick.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerAltClick.kt
@@ -73,6 +73,8 @@ object TriggerAltClick : Trigger("alt_click") {
 
     @EventHandler
     fun handle(event: PlayerInteractEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         if (player.uniqueId in preventDoubleTriggers) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBite.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBite.kt
@@ -18,6 +18,8 @@ object TriggerBite : Trigger("bite") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerFishEvent) {
+        if (!this.isEnabled) return
+
         if (event.state != PlayerFishEvent.State.BITE) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBlank.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBlank.kt
@@ -10,5 +10,5 @@ import com.willfp.libreforge.triggers.TriggerParameter
 object TriggerBlank : Trigger("blank") {
     override var isEnabled = true
 
-    override val parameters = TriggerParameter.values().toSet()
+    override val parameters = TriggerParameter.entries.toSet()
 }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBlockItemDrop.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBlockItemDrop.kt
@@ -29,6 +29,8 @@ object TriggerBlockItemDrop : Trigger("block_item_drop") {
         priority = EventPriority.LOW
     )
     fun handle(event: BlockDropItemEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         val block = event.block
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBowAttack.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBowAttack.kt
@@ -23,6 +23,8 @@ object TriggerBowAttack : Trigger("bow_attack") {
     
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val arrow = event.damager
         val victim = event.entity as? LivingEntity ?: return
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBreed.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBreed.kt
@@ -19,6 +19,8 @@ object TriggerBreed : Trigger("breed") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityBreedEvent) {
+        if (!this.isEnabled) return
+
         val breeder = event.breeder
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBrew.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBrew.kt
@@ -41,6 +41,8 @@ object TriggerBrew : Trigger("brew") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: BrewEvent) {
+        if (!this.isEnabled) return
+
         val location = event.block.location
 
         val player = playerCache[location] ?: return

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBrewIngredient.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBrewIngredient.kt
@@ -25,6 +25,8 @@ object TriggerBrewIngredient : Trigger("brew_ingredient") {
 
     @EventHandler
     fun handle(event: InventoryClickEvent) {
+        if (!this.isEnabled) return
+
         val inventory = event.player.openInventory.topInventory as? BrewerInventory ?: return
         val player = event.player
         val location = inventory.location ?: return
@@ -41,6 +43,8 @@ object TriggerBrewIngredient : Trigger("brew_ingredient") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: BrewEvent) {
+        if (!this.isEnabled) return
+
         val location = event.block.location
 
         val player = playerCache[location] ?: return

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCastRod.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCastRod.kt
@@ -18,6 +18,8 @@ object TriggerCastRod : Trigger("cast_rod") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerFishEvent) {
+        if (!this.isEnabled) return
+
         if (event.state != PlayerFishEvent.State.FISHING) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCatchEntity.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCatchEntity.kt
@@ -21,6 +21,8 @@ object TriggerCatchEntity : Trigger("catch_entity") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerFishEvent) {
+        if (!this.isEnabled) return
+
         if (event.state != PlayerFishEvent.State.CAUGHT_ENTITY) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCatchFish.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCatchFish.kt
@@ -18,6 +18,8 @@ object TriggerCatchFish : Trigger("catch_fish") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerFishEvent) {
+        if (!this.isEnabled) return
+
         if (event.state != PlayerFishEvent.State.CAUGHT_FISH) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCatchFishFail.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCatchFishFail.kt
@@ -18,6 +18,8 @@ object TriggerCatchFishFail : Trigger("catch_fish_fail") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerFishEvent) {
+        if (!this.isEnabled) return
+
         if (event.state != PlayerFishEvent.State.FAILED_ATTEMPT) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerChangeArmor.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerChangeArmor.kt
@@ -15,6 +15,8 @@ object TriggerChangeArmor : Trigger("change_armor") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: ArmorChangeEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerChangeChunk.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerChangeChunk.kt
@@ -22,6 +22,8 @@ object TriggerChangeChunk : Trigger("change_chunk") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityMoveEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         if (!event.hasExplicitlyChangedBlock()) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerChangeWorld.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerChangeWorld.kt
@@ -19,6 +19,8 @@ object TriggerChangeWorld : Trigger("change_world") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerChangedWorldEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerClickBlock.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerClickBlock.kt
@@ -27,6 +27,8 @@ object TriggerClickBlock : Trigger("click_block") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerInteractEvent) {
+        if (!this.isEnabled) return
+
         val block = event.clickedBlock ?: return
         val player = event.player
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerClickEntity.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerClickEntity.kt
@@ -19,6 +19,8 @@ object TriggerClickEntity : Trigger("click_entity") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerInteractEntityEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.rightClicked as? LivingEntity ?: return
         val player = event.player
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCompleteAdvancement.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCompleteAdvancement.kt
@@ -4,10 +4,8 @@ import com.willfp.libreforge.toDispatcher
 import com.willfp.libreforge.triggers.Trigger
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
-import org.bukkit.entity.Item
 import org.bukkit.event.EventHandler
 import org.bukkit.event.player.PlayerAdvancementDoneEvent
-import org.bukkit.event.player.PlayerFishEvent
 
 object TriggerCompleteAdvancement : Trigger("complete_advancement") {
     override val parameters = setOf(
@@ -19,6 +17,8 @@ object TriggerCompleteAdvancement : Trigger("complete_advancement") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerAdvancementDoneEvent) {
+        if (!this.isEnabled) return
+
         if (event.advancement.key.key.startsWith("recipes/")) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerConsume.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerConsume.kt
@@ -17,6 +17,8 @@ object TriggerConsume : Trigger("consume") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerItemConsumeEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         this.dispatch(
             player.toDispatcher(),

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCraft.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerCraft.kt
@@ -23,6 +23,8 @@ object TriggerCraft : Trigger("craft") {
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
     fun handle(event: CraftItemEvent) {
+        if (!this.isEnabled) return
+
         if (event.result == Event.Result.DENY) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDamageItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDamageItem.kt
@@ -18,6 +18,8 @@ object TriggerDamageItem : Trigger("damage_item") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerItemDamageEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDeath.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDeath.kt
@@ -16,6 +16,8 @@ object TriggerDeath : Trigger("death") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerDeathEvent) {
+        if (!this.isEnabled) return
+
         val player = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDeployElytra.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDeployElytra.kt
@@ -19,6 +19,8 @@ object TriggerDeployElytra : Trigger("deploy_elytra") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityToggleGlideEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity as? LivingEntity ?: return
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDisable.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDisable.kt
@@ -15,6 +15,8 @@ object TriggerDisable : Trigger("disable") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: HolderDisableEvent) {
+        if (!this.isEnabled) return
+
         val dispatcher = event.dispatcher
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDrink.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDrink.kt
@@ -27,6 +27,8 @@ object TriggerDrink : Trigger("drink") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerItemConsumeEvent) {
+        if (!this.isEnabled) return
+
         if (!event.item.type.isDrink()) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDropItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerDropItem.kt
@@ -18,6 +18,8 @@ object TriggerDropItem : Trigger("drop_item") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerDropItemEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEmptyBucket.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEmptyBucket.kt
@@ -15,6 +15,8 @@ object TriggerEmptyBucket : Trigger("empty_bucket") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerBucketEmptyEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEnable.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEnable.kt
@@ -15,6 +15,8 @@ object TriggerEnable : Trigger("enable") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: HolderEnableEvent) {
+        if (!this.isEnabled) return
+
         val dispatcher = event.dispatcher
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEnchantItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEnchantItem.kt
@@ -16,6 +16,8 @@ object TriggerEnchantItem : Trigger("enchant_item") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EnchantItemEvent) {
+        if (!this.isEnabled) return
+
         val player = event.enchanter
         val item = event.item
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEnterBed.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEnterBed.kt
@@ -15,6 +15,8 @@ object TriggerEnterBed : Trigger("enter_bed") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerBedEnterEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityBreakDoor.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityBreakDoor.kt
@@ -6,9 +6,7 @@ import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.EventHandler
-import org.bukkit.event.EventPriority
 import org.bukkit.event.entity.EntityBreakDoorEvent
-import org.bukkit.event.entity.EntitySpawnEvent
 
 object TriggerEntityBreakDoor : Trigger("entity_break_door") {
     override val parameters = setOf(
@@ -18,6 +16,8 @@ object TriggerEntityBreakDoor : Trigger("entity_break_door") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityBreakDoorEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityCatchFireFromBlock.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityCatchFireFromBlock.kt
@@ -7,7 +7,6 @@ import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.EventHandler
 import org.bukkit.event.entity.EntityCombustByBlockEvent
-import org.bukkit.event.entity.EntityCombustEvent
 
 object TriggerEntityCatchFireFromBlock : Trigger("entity_catch_fire_from_block") {
     override val parameters = setOf(
@@ -17,6 +16,8 @@ object TriggerEntityCatchFireFromBlock : Trigger("entity_catch_fire_from_block")
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityCombustByBlockEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityCatchFireFromEntity.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityCatchFireFromEntity.kt
@@ -6,9 +6,7 @@ import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.EventHandler
-import org.bukkit.event.entity.EntityCombustByBlockEvent
 import org.bukkit.event.entity.EntityCombustByEntityEvent
-import org.bukkit.event.entity.EntityCombustEvent
 
 object TriggerEntityCatchFireFromEntity : Trigger("entity_catch_fire_from_entity") {
     override val parameters = setOf(
@@ -18,6 +16,8 @@ object TriggerEntityCatchFireFromEntity : Trigger("entity_catch_fire_from_entity
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityCombustByEntityEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityDamage.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityDamage.kt
@@ -7,9 +7,6 @@ import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
-import org.bukkit.event.entity.EntityCombustByBlockEvent
-import org.bukkit.event.entity.EntityCombustByEntityEvent
-import org.bukkit.event.entity.EntityCombustEvent
 import org.bukkit.event.entity.EntityDamageEvent
 
 object TriggerEntityDamage : Trigger("entity_damage") {
@@ -20,6 +17,8 @@ object TriggerEntityDamage : Trigger("entity_damage") {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun handle(event: EntityDamageEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityDamageByEntity.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityDamageByEntity.kt
@@ -7,11 +7,7 @@ import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
-import org.bukkit.event.entity.EntityCombustByBlockEvent
-import org.bukkit.event.entity.EntityCombustByEntityEvent
-import org.bukkit.event.entity.EntityCombustEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
-import org.bukkit.event.entity.EntityDamageEvent
 
 object TriggerEntityDamageByEntity : Trigger("entity_damage_by_entity") {
     override val parameters = setOf(
@@ -21,6 +17,8 @@ object TriggerEntityDamageByEntity : Trigger("entity_damage_by_entity") {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
         val damager = event.damager as? LivingEntity ?: return
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityDeath.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityDeath.kt
@@ -7,10 +7,6 @@ import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
-import org.bukkit.event.entity.EntityCombustByBlockEvent
-import org.bukkit.event.entity.EntityCombustByEntityEvent
-import org.bukkit.event.entity.EntityCombustEvent
-import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.EntityDeathEvent
 
 object TriggerEntityDeath : Trigger("entity_death") {
@@ -21,6 +17,8 @@ object TriggerEntityDeath : Trigger("entity_death") {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun handle(event: EntityDeathEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity as? LivingEntity ?: return
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityItemDrop.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityItemDrop.kt
@@ -24,6 +24,8 @@ object TriggerEntityItemDrop : Trigger("entity_item_drop") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDeathByEntityEvent) {
+        if (!this.isEnabled) return
+
         if (Prerequisite.HAS_PAPER.isMet) {
             if (event.deathEvent.isCancelled) {
                 return

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntitySpawn.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntitySpawn.kt
@@ -17,6 +17,8 @@ object TriggerEntitySpawn : Trigger("entity_spawn") {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun handle(event: EntitySpawnEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityTarget.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityTarget.kt
@@ -17,6 +17,8 @@ object TriggerEntityTarget : Trigger("entity_target") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityTargetEvent) {
+        if (!this.isEnabled) return
+
         val target = event.target ?: return
         val entity = event.entity as? LivingEntity ?: return
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityTeleport.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerEntityTeleport.kt
@@ -6,9 +6,6 @@ import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.EventHandler
-import org.bukkit.event.EventPriority
-import org.bukkit.event.entity.EntityDeathEvent
-import org.bukkit.event.entity.EntityPickupItemEvent
 import org.bukkit.event.entity.EntityTeleportEvent
 
 object TriggerEntityTeleport : Trigger("entity_teleport") {
@@ -19,6 +16,8 @@ object TriggerEntityTeleport : Trigger("entity_teleport") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityTeleportEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerFallDamage.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerFallDamage.kt
@@ -1,6 +1,5 @@
 package com.willfp.libreforge.triggers.impl
 
-import com.willfp.libreforge.GlobalDispatcher.location
 import com.willfp.libreforge.toDispatcher
 import com.willfp.libreforge.triggers.Trigger
 import com.willfp.libreforge.triggers.TriggerData

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerFillBucket.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerFillBucket.kt
@@ -15,6 +15,8 @@ object TriggerFillBucket : Trigger("fill_bucket") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerBucketFillEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerGainHunger.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerGainHunger.kt
@@ -16,6 +16,8 @@ object TriggerGainHunger : Trigger("gain_hunger") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: FoodLevelChangeEvent) {
+        if (!this.isEnabled) return
+
         val player = event.entity as? Player ?: return
 
         if (event.foodLevel < player.foodLevel) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerGainXp.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerGainXp.kt
@@ -15,6 +15,8 @@ object TriggerGainXp : Trigger("gain_xp") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: NaturalExpGainEvent) {
+        if (!this.isEnabled) return
+
         val player = event.expChangeEvent.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHeadshot.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHeadshot.kt
@@ -21,6 +21,8 @@ object TriggerHeadshot : Trigger("headshot") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val projectile = event.damager as? Projectile ?: return
         val victim = event.entity as? LivingEntity ?: return
         val shooter = projectile.shooter as? LivingEntity ?: return

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHeal.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHeal.kt
@@ -16,6 +16,8 @@ object TriggerHeal : Trigger("heal") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityRegainHealthEvent) {
+        if (!this.isEnabled) return
+
         val player = event.entity
 
         if (player !is Player) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHoldItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHoldItem.kt
@@ -17,6 +17,8 @@ object TriggerHoldItem : Trigger("hold_item") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerItemHeldEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         if (event.isCancelled) {
             return

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHookInGround.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHookInGround.kt
@@ -18,6 +18,8 @@ object TriggerHookInGround : Trigger("hook_in_ground") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerFishEvent) {
+        if (!this.isEnabled) return
+
         if (event.state != PlayerFishEvent.State.IN_GROUND) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerItemBreak.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerItemBreak.kt
@@ -16,6 +16,8 @@ object TriggerItemBreak : Trigger("item_break") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerItemBreakEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerJoin.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerJoin.kt
@@ -15,6 +15,8 @@ object TriggerJoin : Trigger("join") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerJoinEvent) {
+        if (!this.isEnabled) return
+
         this.dispatch(
             event.player.toDispatcher(),
             TriggerData(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerJump.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerJump.kt
@@ -17,6 +17,8 @@ object TriggerJump : Trigger("jump") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerJumpEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerKill.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerKill.kt
@@ -21,6 +21,8 @@ object TriggerKill : Trigger("kill") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDeathByEntityEvent) {
+        if (!this.isEnabled) return
+
         val killer = event.killer.tryAsLivingEntity() ?: return
 
         val victim = event.victim

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLeashEntity.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLeashEntity.kt
@@ -18,6 +18,8 @@ object TriggerLeashEntity : Trigger("leash_entity") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerLeashEntityEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLeave.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLeave.kt
@@ -15,6 +15,8 @@ object TriggerLeave : Trigger("leave") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerQuitEvent) {
+        if (!this.isEnabled) return
+
         this.dispatch(
             event.player.toDispatcher(),
             TriggerData(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLeaveBed.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLeaveBed.kt
@@ -15,6 +15,8 @@ object TriggerLeaveBed : Trigger("leave_bed") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerBedLeaveEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLevelUpItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLevelUpItem.kt
@@ -15,6 +15,8 @@ object TriggerLevelUpItem : Trigger("level_up_item") {
 
     @EventHandler
     fun handle(event: ItemLevelUpEvent) {
+        if (!this.isEnabled) return
+
         this.dispatch(
             event.player.toDispatcher(),
             TriggerData(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLevelUpXp.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLevelUpXp.kt
@@ -15,6 +15,8 @@ object TriggerLevelUpXp : Trigger("level_up_xp") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerLevelChangeEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         if (event.newLevel < event.oldLevel) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLoseHunger.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLoseHunger.kt
@@ -16,6 +16,8 @@ object TriggerLoseHunger : Trigger("lose_hunger") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: FoodLevelChangeEvent) {
+        if (!this.isEnabled) return
+
         val player = event.entity as? Player ?: return
 
         if (event.foodLevel > player.foodLevel) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLosePotionEffect.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerLosePotionEffect.kt
@@ -19,6 +19,8 @@ object TriggerLosePotionEffect : Trigger("lose_potion_effect") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityPotionEffectEvent) {
+        if (!this.isEnabled) return
+
         if (event.oldEffect == null) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMeleeAttack.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMeleeAttack.kt
@@ -21,6 +21,8 @@ object TriggerMeleeAttack : Trigger("melee_attack") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val attacker = event.damager as? LivingEntity ?: return
         val victim = event.entity as? LivingEntity ?: return
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMineBlock.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMineBlock.kt
@@ -20,6 +20,8 @@ object TriggerMineBlock : Trigger("mine_block") {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun handle(event: BlockBreakEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         val block = event.block
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMineBlockProgress.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMineBlockProgress.kt
@@ -18,6 +18,8 @@ object TriggerMineBlockProgress : Trigger("mine_block_progress") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: BlockDamageEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         val block = event.block
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMove.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMove.kt
@@ -21,6 +21,8 @@ object TriggerMove : Trigger("move") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityMoveEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         if (entity is Player) {
@@ -52,6 +54,8 @@ object TriggerMove : Trigger("move") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerMoveEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         if (Prerequisite.HAS_PAPER.isMet) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPickUpItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPickUpItem.kt
@@ -18,6 +18,8 @@ object TriggerPickUpItem : Trigger("pick_up_item") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityPickupItemEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPlaceBlock.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPlaceBlock.kt
@@ -19,6 +19,8 @@ object TriggerPlaceBlock : Trigger("place_block") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: BlockPlaceEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         val block = event.blockPlaced
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPotionEffect.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPotionEffect.kt
@@ -20,6 +20,8 @@ object TriggerPotionEffect : Trigger("potion_effect") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityPotionEffectEvent) {
+        if (!this.isEnabled) return
+
         if (event.newEffect == null) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerProjectileHit.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerProjectileHit.kt
@@ -24,6 +24,8 @@ object TriggerProjectileHit : Trigger("projectile_hit") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: ProjectileHitEvent) {
+        if (!this.isEnabled) return
+
         val projectile = event.entity
         val shooter = projectile.shooter as? LivingEntity ?: return
 
@@ -42,6 +44,8 @@ object TriggerProjectileHit : Trigger("projectile_hit") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val arrow = event.damager as? Arrow ?: return
         val victim = event.entity as? LivingEntity ?: return
         val shooter = arrow.shooter as? LivingEntity ?: return

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerProjectileLaunch.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerProjectileLaunch.kt
@@ -21,6 +21,8 @@ object TriggerProjectileLaunch : Trigger("projectile_launch") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: ProjectileLaunchEvent) {
+        if (!this.isEnabled) return
+
         val shooter = event.entity.shooter as? LivingEntity ?: return
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerReelIn.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerReelIn.kt
@@ -18,6 +18,8 @@ object TriggerReelIn : Trigger("reel_in") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerFishEvent) {
+        if (!this.isEnabled) return
+
         if (event.state != PlayerFishEvent.State.REEL_IN) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerRespawn.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerRespawn.kt
@@ -15,6 +15,8 @@ object TriggerRespawn : Trigger("respawn") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerRespawnEvent) {
+        if (!this.isEnabled) return
+
         this.dispatch(
             event.player.toDispatcher(),
             TriggerData(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerRunCommand.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerRunCommand.kt
@@ -17,6 +17,8 @@ object TriggerRunCommand : Trigger("run_command") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerCommandPreprocessEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         plugin.scheduler.run {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSellItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSellItem.kt
@@ -16,6 +16,8 @@ object TriggerSellItem : Trigger("sell_item") {
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
     fun handle(event: ShopSellEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         val item = event.item
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSendMessage.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSendMessage.kt
@@ -20,10 +20,9 @@ object TriggerSendMessage : Trigger("send_message") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: AsyncPlayerChatEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
-        if (event.isCancelled) {
-            return
-        }
 
         plugin.scheduler.run {
             this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerShearEntity.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerShearEntity.kt
@@ -19,6 +19,8 @@ object TriggerShearEntity : Trigger("shear_entity") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerShearEntityEvent) {
+        if (!this.isEnabled) return
+
         val entity = event.entity as? LivingEntity ?: return
 
         if (entity.type !in listOf(EntityType.SHEEP, EntityType.MUSHROOM_COW)) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerShieldBlock.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerShieldBlock.kt
@@ -20,6 +20,8 @@ object TriggerShieldBlock : Trigger("shield_block") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val attacker = event.damager as? LivingEntity ?: return
         val victim = event.entity as? LivingEntity ?: return
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerShootBow.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerShootBow.kt
@@ -21,6 +21,8 @@ object TriggerShootBow : Trigger("shoot_bow") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityShootBowEvent) {
+        if (!this.isEnabled) return
+
         val shooter = event.entity as? LivingEntity ?: return
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSmelt.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSmelt.kt
@@ -25,6 +25,8 @@ object TriggerSmelt : Trigger("smelt") {
 
     @EventHandler
     fun handle(event: InventoryClickEvent) {
+        if (!this.isEnabled) return
+
         val inventory = event.player.openInventory.topInventory as? FurnaceInventory ?: return
         val player = event.player
         val location = inventory.location ?: return
@@ -41,6 +43,8 @@ object TriggerSmelt : Trigger("smelt") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: FurnaceSmeltEvent) {
+        if (!this.isEnabled) return
+
         if (event.block.state !is Furnace) {
             return
         }

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSmithItem.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSmithItem.kt
@@ -6,7 +6,6 @@ import com.willfp.libreforge.triggers.Trigger
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.event.EventHandler
-import org.bukkit.event.enchantment.EnchantItemEvent
 import org.bukkit.event.inventory.SmithItemEvent
 
 object TriggerSmithItem : Trigger("smith_item") {
@@ -18,6 +17,8 @@ object TriggerSmithItem : Trigger("smith_item") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: SmithItemEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
         val item = event.inventory.result
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSwapHands.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerSwapHands.kt
@@ -17,10 +17,9 @@ object TriggerSwapHands : Trigger("swap_hands") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerSwapHandItemsEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
-        if (event.isCancelled) {
-            return
-        }
 
         this.dispatch(
             player.toDispatcher(),

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTakeDamage.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTakeDamage.kt
@@ -31,6 +31,8 @@ object TriggerTakeDamage : Trigger("take_damage") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageEvent) {
+        if (!this.isEnabled) return
+
         val victim = event.entity
 
         if (event.cause in ignoredCauses) {

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTakeEntityDamage.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTakeEntityDamage.kt
@@ -20,6 +20,8 @@ object TriggerTakeEntityDamage : Trigger("take_entity_damage") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val attacker = event.damager.tryAsLivingEntity() ?: return
 
         val victim = event.entity

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTameAnimal.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTameAnimal.kt
@@ -18,6 +18,8 @@ object TriggerTameAnimal : Trigger("tame_animal") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityTameEvent) {
+        if (!this.isEnabled) return
+
         val player = event.owner as? Player ?: return
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTeleport.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTeleport.kt
@@ -17,6 +17,8 @@ object TriggerTeleport : Trigger("teleport") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerTeleportEvent) {
+        if (!this.isEnabled) return
+
         plugin.scheduler.run {
             this.dispatch(
                 event.player.toDispatcher(),

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerToggleFlight.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerToggleFlight.kt
@@ -17,6 +17,8 @@ object TriggerToggleFlight : Trigger("toggle_flight") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerToggleFlightEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerToggleSneak.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerToggleSneak.kt
@@ -17,6 +17,8 @@ object TriggerToggleSneak : Trigger("toggle_sneak") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerToggleSneakEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerToggleSprint.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerToggleSprint.kt
@@ -17,6 +17,8 @@ object TriggerToggleSprint : Trigger("toggle_sprint") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: PlayerToggleSprintEvent) {
+        if (!this.isEnabled) return
+
         val player = event.player
 
         this.dispatch(

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTridentAttack.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTridentAttack.kt
@@ -29,6 +29,8 @@ object TriggerTridentAttack : Trigger("trident_attack") {
 
     @EventHandler(ignoreCancelled = true)
     fun onProjectileLaunch(event: ProjectileLaunchEvent) {
+        if (!this.isEnabled) return
+
         val shooter = event.entity.shooter as? LivingEntity ?: return
         val trident = event.entity as? Trident ?: return
 
@@ -40,6 +42,8 @@ object TriggerTridentAttack : Trigger("trident_attack") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
+        if (!this.isEnabled) return
+
         val trident = event.damager as? Trident ?: return
         val victim = event.entity as? LivingEntity ?: return
 

--- a/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerWinRaid.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerWinRaid.kt
@@ -15,6 +15,8 @@ object TriggerWinRaid : Trigger("win_raid") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: RaidFinishEvent) {
+        if (!this.isEnabled) return
+
         for (player in event.winners) {
             this.dispatch(
                 player.toDispatcher(),

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -145,7 +145,7 @@ refresh:
     timeout: 500
 
   holders:
-    # Delay in seconds for refreshing holders and effects after inventory updates.
+    # Delay in ticks for refreshing holders and effects after inventory updates.
     # You can increase value, if your server not fast enough to update inventories in async.
     # It is recommended not to set the value lower than 2; otherwise, the server may not have sufficient time to update data.
     update-delay: 2

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -121,6 +121,10 @@ refresh:
     # If picked up items must have item meta (NBT Data) in order to trigger a refresh
     require-meta: true
 
+  held:
+    # If swap items in HotBar must have item meta (NBT Data) in order to trigger a refresh
+    require-meta: true
+
   entities:
     # If entities should be polled for updates, and how often (in ticks).
     # If you don't have any effects that run from entities, you can disable this to save performance.
@@ -130,7 +134,18 @@ refresh:
     # can make effects feel less responsive.
     interval: 60
 
+  players:
+    # Skip AFK players for effect updates for performance reasons.
+    # If you need to update effects on AFK players, you can set false.
+    skip-afk-players: true
+
   inventory-click:
     # Inventory clicks refresh active holders, but a group of malicious users spamming can cause server lag.
     # Setting a timeout ensures only one click triggers a refresh within the specified time (in milliseconds).
     timeout: 500
+
+  holders:
+    # Delay in seconds for refreshing holders and effects after inventory updates.
+    # You can increase value, if your server not fast enough to update inventories in async.
+    # It is recommended not to set the value lower than 2; otherwise, the server may not have sufficient time to update data.
+    update-delay: 2


### PR DESCRIPTION
**List of changes**
- ItemHolderFinderProvider now calculates async to avoid performance problems with it.
  For proper updating we need to delay refreshHolders and refreshEffects (I tested and see that 2 ticks enough to that)
  But for slow servers there is option in config to change that delay.
  I think it's better to use it in async than calculate every time full inventory with different SlotTypes in main thread.

- Added cache of hashcode in SimpleProvidedHolder and ItemProvidedHolder.
- PlayerItemHeldEvent as HolderUpdate now have check for items with itemMeta for performance reasons (can be changed in config).
- Added option to exclude AFK players from refreshHolders runTimer.
- Removed in ConditionBlock computations of cache, it's lower performance, when using a lot of conditions.
  default-state-off-main-thread from config will be better in my opinion or it can be changed to Random(), but not caching that.
- BoundCounters now provides without creating list (saving performance).
- Fixed EffectRegenMultiplier. Incorrect reason key.
- EffectSpawnParticle now spawn particles async, It's safe to use in this way and better for performance.
- ElementLike -> changed injectPlaceholders to faster calculations, avoid map creation; optimised ElementLike.trigger with some checks to avoid generating placeholders for nothing.
- All triggers now doesn't do anything if they disabled. IsEnabled check moved to events directly to avoid generating TriggerData.
- Optimisation for Trigger.dispatchOnEffects to avoid unnecessary calculations.
- Removed unused libraries in triggers classes.
- Updated Caffeine lib.
