### PR TITLE
Add AuraSkills 2.0 integration

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
     compileOnly("net.kyori:adventure-text-minimessage:4.14.0")
 
+    compileOnly("dev.aurelium:auraskills-api-bukkit:2.0.0")
     compileOnly("com.github.Archy-X:AureliumSkills:Beta1.2.4")
     compileOnly("com.gmail.nossr50.mcMMO:mcMMO:2.1.202") {
         exclude(group = "com.sk89q.worldedit", module = "worldedit-core")

--- a/core/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
@@ -1,6 +1,5 @@
 package com.willfp.libreforge
 
-import com.gmail.nossr50.mcMMO.p
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.core.Prerequisite
 import com.willfp.eco.core.command.impl.PluginCommand
@@ -12,6 +11,7 @@ import com.willfp.libreforge.configs.lrcdb.CommandLrcdb
 import com.willfp.libreforge.effects.Effects
 import com.willfp.libreforge.effects.arguments.custom.CustomEffectArguments
 import com.willfp.libreforge.effects.impl.bossbar.BossBarProgressPlaceholder
+import com.willfp.libreforge.integrations.auraskills.AuraSkillsIntegration
 import com.willfp.libreforge.integrations.aureliumskills.AureliumSkillsIntegration
 import com.willfp.libreforge.integrations.citizens.CitizensIntegration
 import com.willfp.libreforge.integrations.custombiomes.impl.CustomBiomesTerra
@@ -27,12 +27,7 @@ import com.willfp.libreforge.integrations.tmmobcoins.TMMobcoinsIntegration
 import com.willfp.libreforge.integrations.vault.VaultIntegration
 import com.willfp.libreforge.integrations.worldguard.WorldGuardIntegration
 import com.willfp.libreforge.levels.LevelTypes
-import com.willfp.libreforge.levels.placeholder.ItemDataPlaceholder
-import com.willfp.libreforge.levels.placeholder.ItemLevelPlaceholder
-import com.willfp.libreforge.levels.placeholder.ItemPointsPlaceholder
-import com.willfp.libreforge.levels.placeholder.ItemProgressPlaceholder
-import com.willfp.libreforge.levels.placeholder.ItemXPPlaceholder
-import com.willfp.libreforge.levels.placeholder.ItemXPRequiredPlaceholder
+import com.willfp.libreforge.levels.placeholder.*
 import com.willfp.libreforge.placeholders.CustomPlaceholders
 import com.willfp.libreforge.triggers.DispatchedTriggerFactory
 import org.bukkit.Bukkit
@@ -170,6 +165,7 @@ class LibreforgeSpigotPlugin : EcoPlugin() {
 
     override fun loadIntegrationLoaders(): List<IntegrationLoader> {
         return listOf(
+            IntegrationLoader("AuraSkills") { AuraSkillsIntegration.load(this) },
             IntegrationLoader("AureliumSkills") { AureliumSkillsIntegration.load(this) },
             IntegrationLoader("Jobs") { JobsIntegration.load(this) },
             IntegrationLoader("LevelledMobs") { LevelledMobsIntegration.load(this) },

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsIntegration.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsIntegration.kt
@@ -1,0 +1,29 @@
+package com.willfp.libreforge.integrations.auraskills
+
+import com.willfp.eco.core.EcoPlugin
+import com.willfp.libreforge.conditions.Conditions
+import com.willfp.libreforge.effects.Effects
+import com.willfp.libreforge.effects.arguments.EffectArguments
+import com.willfp.libreforge.integrations.LoadableIntegration
+import com.willfp.libreforge.integrations.auraskills.impl.ArgumentManaCost
+import com.willfp.libreforge.integrations.auraskills.impl.ConditionHasMana
+import com.willfp.libreforge.integrations.auraskills.impl.EffectAddStat
+import com.willfp.libreforge.integrations.auraskills.impl.EffectSkillXpMultiplier
+
+object AuraSkillsIntegration : LoadableIntegration {
+
+    override fun load(plugin: EcoPlugin) {
+        if (plugin.server.pluginManager.getPlugin("EcoSkills") != null) {
+            return
+        }
+
+        Effects.register(EffectAddStat)
+        Conditions.register(ConditionHasMana)
+        Effects.register(EffectSkillXpMultiplier)
+        EffectArguments.register(ArgumentManaCost)
+    }
+
+    override fun getPluginName(): String {
+        return "AuraSkills"
+    }
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/ArgumentManaCost.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/ArgumentManaCost.kt
@@ -1,0 +1,59 @@
+package com.willfp.libreforge.integrations.auraskills.impl
+
+import com.willfp.eco.util.NumberUtils
+import com.willfp.eco.util.PlayerUtils
+import com.willfp.eco.util.StringUtils
+import com.willfp.libreforge.*
+import com.willfp.libreforge.effects.arguments.EffectArgument
+import com.willfp.libreforge.triggers.DispatchedTrigger
+import dev.aurelium.auraskills.api.AuraSkillsApi
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+
+object ArgumentManaCost : EffectArgument<NoCompileData>("mana_cost") {
+    override fun isMet(element: ConfigurableElement, trigger: DispatchedTrigger, compileData: NoCompileData): Boolean {
+        val player = trigger.dispatcher.get<Player>() ?: return false
+
+        val cost = element.config.getDoubleFromExpression("mana_cost", trigger.data)
+
+        return AuraSkillsApi.get().getUser(player.uniqueId).mana >= cost
+    }
+
+    override fun ifMet(element: ConfigurableElement, trigger: DispatchedTrigger, compileData: NoCompileData) {
+        val player = trigger.dispatcher.get<Player>() ?: return
+
+        val cost = element.config.getDoubleFromExpression("mana_cost", trigger.data)
+
+        val user = AuraSkillsApi.get().getUser(player.uniqueId)
+        user.mana -= cost
+    }
+
+    override fun ifNotMet(element: ConfigurableElement, trigger: DispatchedTrigger, compileData: NoCompileData) {
+        val player = trigger.dispatcher.get<Player>() ?: return
+
+        val cost = element.config.getDoubleFromExpression("mana_cost", trigger.data)
+
+        if (!plugin.configYml.getBool("cannot-afford-type.message-enabled")) {
+            return
+        }
+
+        val message = plugin.langYml.getFormattedString("messages.cannot-afford-type")
+            .replace("%cost%", NumberUtils.format(cost))
+            .replace("%type%", "mana".toFriendlyPointName())
+
+        if (plugin.configYml.getBool("cannot-afford-type.in-actionbar")) {
+            PlayerUtils.getAudience(player).sendActionBar(StringUtils.toComponent(message))
+        } else {
+            player.sendMessage(message)
+        }
+
+        if (plugin.configYml.getBool("cannot-afford-type.sound.enabled")) {
+            player.playSound(
+                player.location,
+                Sound.valueOf(plugin.configYml.getString("cannot-afford-type.sound.sound").uppercase()),
+                1.0f,
+                plugin.configYml.getDouble("cannot-afford-type.sound.pitch").toFloat()
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/ConditionHasMana.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/ConditionHasMana.kt
@@ -1,0 +1,32 @@
+package com.willfp.libreforge.integrations.auraskills.impl
+
+import com.archyx.aureliumskills.api.event.ManaRegenerateEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.*
+import com.willfp.libreforge.conditions.Condition
+import dev.aurelium.auraskills.api.AuraSkillsApi
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+
+object ConditionHasMana : Condition<NoCompileData>("has_mana") {
+    override val arguments = arguments {
+        require("amount", "You must specify the amount of mana!")
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun handle(event: ManaRegenerateEvent) {
+        event.player.toDispatcher().updateEffects()
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+
+        return AuraSkillsApi.get().getUser(player.uniqueId).mana > config.getDoubleFromExpression("amount", player)
+    }
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/EffectAddStat.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/EffectAddStat.kt
@@ -1,0 +1,44 @@
+package com.willfp.libreforge.integrations.auraskills.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.*
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.effects.Identifiers
+import dev.aurelium.auraskills.api.AuraSkillsApi
+import dev.aurelium.auraskills.api.registry.NamespacedId
+import dev.aurelium.auraskills.api.stat.StatModifier
+import org.bukkit.entity.Player
+
+object EffectAddStat : Effect<NoCompileData>("add_stat") {
+    override val arguments = arguments {
+        require("stat", "You must specify the stat!")
+        require("amount", "You must specify the amount!")
+    }
+
+    override fun onEnable(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        identifiers: Identifiers,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ) {
+        val player = dispatcher.get<Player>() ?: return
+
+        val auraSkills = AuraSkillsApi.get()
+        val user = auraSkills.getUser(player.uniqueId)
+        val stat = auraSkills.globalRegistry.getStat(NamespacedId.fromDefault(config.getString("stat")))
+
+        user.addStatModifier(StatModifier(
+            identifiers.key.key,
+            stat,
+            config.getDoubleFromExpression("amount", player)
+        ))
+    }
+
+    override fun onDisable(dispatcher: Dispatcher<*>, identifiers: Identifiers, holder: ProvidedHolder) {
+        val player = dispatcher.get<Player>() ?: return
+
+        val user = AuraSkillsApi.get().getUser(player.uniqueId)
+        user.removeStatModifier(identifiers.key.key)
+    }
+}

--- a/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/EffectSkillXpMultiplier.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/EffectSkillXpMultiplier.kt
@@ -1,0 +1,31 @@
+package com.willfp.libreforge.integrations.auraskills.impl
+
+import com.willfp.libreforge.effects.templates.MultiMultiplierEffect
+import com.willfp.libreforge.toDispatcher
+import dev.aurelium.auraskills.api.AuraSkillsApi
+import dev.aurelium.auraskills.api.event.skill.XpGainEvent
+import dev.aurelium.auraskills.api.registry.NamespacedId
+import dev.aurelium.auraskills.api.skill.Skill
+import org.bukkit.event.EventHandler
+
+object EffectSkillXpMultiplier : MultiMultiplierEffect<Skill>("skill_xp_multiplier") {
+    override val key = "skills"
+
+    override fun getElement(key: String): Skill {
+        return AuraSkillsApi.get().globalRegistry.getSkill(NamespacedId.fromDefault(key))
+            ?: throw IllegalArgumentException("Unknown skill $key")
+    }
+
+    override fun getAllElements(): Collection<Skill> {
+        return AuraSkillsApi.get().globalRegistry.skills
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: XpGainEvent) {
+        val player = event.player
+
+        val multiplier = getMultiplier(player.toDispatcher(), event.skill)
+
+        event.amount *= multiplier
+    }
+}


### PR DESCRIPTION
This PR adds support for AuraSkills 2.0 (formerly AureliumSkills). 2.0 has a completely new API with separate packages and a different plugin name so the old AureliumSkills integration can still exist at the same time and work for users using AureliumSkills. I haven't tested if this fully works but I just based it off the existing AureliumSkills integration, so let me know if I missed anything.

[2.0 API docs if needed](https://wiki.aurelium.dev/auraskills/api)