### PR TITLE
Added optional 'amount' (minimum entities matched) arg to 'near_entity'.

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionNearEntity.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionNearEntity.kt
@@ -26,9 +26,13 @@ object ConditionNearEntity : Condition<Collection<TestableEntity>>("near_entity"
         val location = dispatcher.location ?: return false
         val radius = config.getDoubleFromExpression("radius", dispatcher.get())
 
-        return location.world.getNearbyEntities(location, radius, radius, radius).any {
+        // Default to require there to be at least 1 entity if no minimum is defined by the user.
+        val nearbyEntityMinimumRequirement = config.getIntOrNull("amount") ?: 1
+        val nearbyEntitiesWhichMatchCriteria = location.world.getNearbyEntities(location, radius, radius, radius).count {
             compileData.any { test -> test.matches(it) }
         }
+
+        return nearbyEntitiesWhichMatchCriteria >= nearbyEntityMinimumRequirement
     }
 
     override fun makeCompileData(config: Config, context: ViolationContext): Collection<TestableEntity> {


### PR DESCRIPTION
example:
```YAML
enabled: true

effects:
  - id: send_message
    args:
      message: "At least 2 zombies"
    triggers:
      - click_entity
    conditions:
      - id: near_entity
        args:
            radius: 10
            entities:
              - Zombie
            amount: 2
```