### PR TITLE
fix attributes on version < 1.21

### DIFF
--- a/core/src/main/kotlin/com/willfp/libreforge/effects/templates/AttributeEffect.kt
+++ b/core/src/main/kotlin/com/willfp/libreforge/effects/templates/AttributeEffect.kt
@@ -111,7 +111,7 @@ abstract class AttributeEffect(
         } else {
             @Suppress("DEPRECATION", "REMOVAL")
             AttributeModifier(
-                UUID.randomUUID(),
+                identifiers.uuid,
                 name,
                 value,
                 operation


### PR DESCRIPTION
Attributes not properly removing on version < 1.21, because of random UUID