### PR TITLE
Fix add_stat AuraSkills integration

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/Effect.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/Effect.kt
@@ -88,7 +88,7 @@ abstract class Effect<T>(
 
         val withHolder = config.config.applyHolder(holder, dispatcher)
 
-        onEnable(dispatcher, withHolder, identifierFactory.makeIdentifiers(count), holder, config.compileData)
+        onEnable(dispatcher, withHolder, identifierFactory.makeIdentifiers(count), holder, config.compileData, isReload)
 
         // Legacy support
         dispatcher.ifType<Player> {
@@ -105,9 +105,24 @@ abstract class Effect<T>(
         config: Config,
         identifiers: Identifiers,
         holder: ProvidedHolder,
-        compileData: T
+        compileData: T,
     ) {
         // Override when needed.
+    }
+
+    /**
+     * Handle the enabling of this permanent effect.
+     */
+    protected open fun onEnable(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        identifiers: Identifiers,
+        holder: ProvidedHolder,
+        compileData: T,
+        isReload: Boolean = false
+    ) {
+        // Override when needed.
+        onEnable(dispatcher, config, identifiers, holder, compileData)
     }
 
     /**
@@ -128,7 +143,7 @@ abstract class Effect<T>(
 
         val count = effectCounter[dispatcher.uuid]--
 
-        onDisable(dispatcher, identifierFactory.makeIdentifiers(count), holder)
+        onDisable(dispatcher, identifierFactory.makeIdentifiers(count), holder, isReload)
 
         // Legacy support
         dispatcher.ifType<Player> {
@@ -143,9 +158,22 @@ abstract class Effect<T>(
     protected open fun onDisable(
         dispatcher: Dispatcher<*>,
         identifiers: Identifiers,
-        holder: ProvidedHolder
+        holder: ProvidedHolder,
     ) {
         // Override when needed.
+    }
+
+    /**
+     * Handle the disabling of this permanent effect.
+     */
+    protected open fun onDisable(
+        dispatcher: Dispatcher<*>,
+        identifiers: Identifiers,
+        holder: ProvidedHolder,
+        isReload: Boolean = false
+    ) {
+        // Override when needed.
+        onDisable(dispatcher, identifiers, holder)
     }
 
     /**

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/EffectAddStat.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/impl/EffectAddStat.kt
@@ -28,17 +28,25 @@ object EffectAddStat : Effect<NoCompileData>("add_stat") {
         val user = auraSkills.getUser(player.uniqueId)
         val stat = auraSkills.globalRegistry.getStat(NamespacedId.fromDefault(config.getString("stat")))
 
-        user.addStatModifier(StatModifier(
-            identifiers.key.key,
-            stat,
-            config.getDoubleFromExpression("amount", player)
-        ))
+        user.addStatModifier(
+            StatModifier(
+                identifiers.key.key,
+                stat,
+                config.getDoubleFromExpression("amount", player)
+            )
+        )
     }
 
-    override fun onDisable(dispatcher: Dispatcher<*>, identifiers: Identifiers, holder: ProvidedHolder) {
+    override fun onDisable(
+        dispatcher: Dispatcher<*>,
+        identifiers: Identifiers,
+        holder: ProvidedHolder,
+        isReload: Boolean
+    ) {
+        if (isReload) return
         val player = dispatcher.get<Player>() ?: return
-
         val user = AuraSkillsApi.get().getUser(player.uniqueId)
+
         user.removeStatModifier(identifiers.key.key)
     }
 }


### PR DESCRIPTION
New overrides for onEnable and onDisable to properly detect a reload. It calls the old ones so existing Effects are not affected.
Other effects, like add_stat that needs the information whether the disable/enable happens because of a reload or not, can properly override the new methods.

This is needed so for example health stat won't get removed then readded instantly on an effect reload which would cause the player constant damage.

If only the value changes, you can add a new modifier with the same key and the new value, which will be handled accordingly.
This is mainly for fixing the health bug, but it is also better in general for every stat, because it will reduce many extra calls if the values are not changing.

Will fix:
- https://discord.com/channels/452518336627081236/1261726524860530789
- https://discord.com/channels/452518336627081236/1255922888112996463