### PR TITLE
added spawner entity filter

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/filters/Filters.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/filters/Filters.kt
@@ -33,6 +33,7 @@ import com.willfp.libreforge.filters.impl.FilterPlayerName
 import com.willfp.libreforge.filters.impl.FilterPlayerPlaced
 import com.willfp.libreforge.filters.impl.FilterPotionEffect
 import com.willfp.libreforge.filters.impl.FilterProjectiles
+import com.willfp.libreforge.filters.impl.FilterSpawnerEntity
 import com.willfp.libreforge.filters.impl.FilterText
 import com.willfp.libreforge.filters.impl.FilterTextContains
 import com.willfp.libreforge.filters.impl.FilterThisItem
@@ -120,5 +121,6 @@ object Filters : Registry<Filter<*, *>>() {
         register(FilterAdvancements)
         register(FilterThisItem)
         register(FilterEnchant)
+        register(FilterSpawnerEntity)
     }
 }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/filters/impl/FilterSpawnerEntity.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/filters/impl/FilterSpawnerEntity.kt
@@ -1,0 +1,28 @@
+package com.willfp.libreforge.filters.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.util.containsIgnoreCase
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+import org.bukkit.block.CreatureSpawner
+
+object FilterSpawnerEntity : Filter<NoCompileData, Collection<String>>("spawner_entity") {
+
+    override fun getValue(config: Config, data: TriggerData?, key: String): Collection<String> {
+        return config.getStrings(key)
+    }
+
+    override fun isMet(data: TriggerData, value: Collection<String>, compileData: NoCompileData): Boolean {
+        val block = data.block ?: return false
+
+        if (block.state is CreatureSpawner) {
+            val spawner = block.state as CreatureSpawner
+            val spawnerEntityType = spawner.spawnedType?.name ?: "null"
+
+            return value.containsIgnoreCase(spawnerEntityType)
+        }
+
+        return false
+    }
+}


### PR DESCRIPTION
Added `spawner_entity` filter. This is to be used with a mine_block trigger to only action when a spawner of x entity type was mined.