### PR TITLE
Added ability to disable holder update on item pickup

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
@@ -29,6 +29,10 @@ class ItemRefreshListener(
 
     @EventHandler(priority = EventPriority.LOWEST)
     fun onItemPickup(event: EntityPickupItemEvent) {
+        if (!plugin.configYml.getBool("refresh.pickup.enabled")) {
+            return
+        }
+
         if (plugin.configYml.getBool("refresh.pickup.require-meta")) {
             if (!event.item.itemStack.hasItemMeta()) {
                 return

--- a/core/common/src/main/resources/config.yml
+++ b/core/common/src/main/resources/config.yml
@@ -141,6 +141,8 @@ refresh:
   cooldown: 250
 
   pickup:
+    # If picked up items should trigger a refresh
+    enabled: true
     # If picked up items must have item meta (NBT Data) in order to trigger a refresh
     require-meta: true
 


### PR DESCRIPTION
Optionally disable holder updates for item pickup events.

Relevant spark report sent by someone on Discord: https://spark.lucko.me/ZHLJzWdiTK

### Use case
1. For example on my server, I will only use Pets and Talismans. There is no reason for this to refresh anything since talismans will only work in the Talismans inventory.
2. Optionally disabling something that will fix itself instantly when you do anything in your inventory is fine IMO if the result prevents the server from crashing by some dumb mob farm players.