### PR TITLE
Fix force loading of libreforge.jar multiple times

### DIFF
--- a/loader/src/main/kotlin/com/willfp/libreforge/loader/internal/LibreforgeLoader.kt
+++ b/loader/src/main/kotlin/com/willfp/libreforge/loader/internal/LibreforgeLoader.kt
@@ -32,6 +32,8 @@ internal fun checkHighestVersion(plugin: LibreforgePlugin) {
 }
 
 internal fun tryLoadForceVersion(pluginFolder: File) {
+    if (Bukkit.getPluginManager().plugins.any { it.name == "libreforge" }) return
+
     val libreforgeFolder = pluginFolder.resolve("libreforge")
     val versionsFolder = libreforgeFolder.resolve("versions")
 


### PR DESCRIPTION
At present, nobody can really use custom libreforge forks with multiple eco plugins. This PR fixes this issue by preventing the eco plugins from force-loading libreforge multiple times. 

### Use case
I would like to disable/improve a lot of holder updates and make changes to the other eco plugins as well to optimize the hell out of them and remove the refreshes I don't need, or to make the entire effect system semi async maybe. I need to test it with almost every eco plugin if I ever want to merge this back (though I highly doubt you would accept something like this).

Will be much easier if this would just work and I wouldn't need to patch every eco plugin individually, to properly force load custom versions of libreforge.