### PR TITLE
FEAT: Added ability to use `projectile` filter with `headshot` trigger

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHeadshot.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerHeadshot.kt
@@ -38,7 +38,8 @@ object TriggerHeadshot : Trigger("headshot") {
                 location = victim.location,
                 event = event,
                 velocity = projectile.velocity,
-                value = event.finalDamage
+                value = event.finalDamage,
+                projectile = projectile
             )
         )
     }


### PR DESCRIPTION
For my quests in EcoQuests I added abilty to filter projectiles, that can be used in headshot trigger. 

To test it you can use this simple task in quest:

```
description: "&fMake headshot by arrow (&a%xp%&8/&a%required-xp%&f)"

xp-gain-methods:
  - trigger: headshot
    value: 1
    filters:
      projectiles:
        - arrow
```

