### PR TITLE
Update EffectReplantCrops.kt

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectReplantCrops.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectReplantCrops.kt
@@ -82,12 +82,12 @@ object EffectReplantCrops : Effect<NoCompileData>("replant_crops") {
             return
         }
 
-        val consumeSeeds = players[player.uniqueId].any {
-            it.consumeSeeds
-        }
+        val playerConfigs = players[player.uniqueId]
+        val consumeSeeds = playerConfigs.any { it.consumeSeeds }
+        val onlyFullyGrown = playerConfigs.all { it.onlyFullyGrown }
 
-        val onlyFullyGrown = players[player.uniqueId].all {
-            it.onlyFullyGrown
+        if (onlyFullyGrown && data.age != data.maximumAge) {
+            return
         }
 
         if (consumeSeeds) {


### PR DESCRIPTION
This PR fixes an issue whereby if both `consume_seeds` and `only_fully_grown` are true, if a player breaks a non-fully-grown crop, it: breaks the crop, does not replant, drops the seed but ALSO consumes a seed. Meaning for each ungrown crop broken, the player loses a seed each time.