### PR TITLE
Fix those damn placeholder conditions

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderGreaterThan.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderGreaterThan.kt
@@ -25,7 +25,7 @@ object ConditionPlaceholderGreaterThan : Condition<NoCompileData>("placeholder_g
     ): Boolean {
         val player = dispatcher.get<Player>()
 
-        return (config.getFormattedString("placeholder", placeholderContext(player = player))
-            .toDoubleOrNull() ?: 0.0) > config.getDoubleFromExpression("value", player)
+        return (config.getDoubleFromExpression("placeholder", placeholderContext(player = player))
+                ) >= config.getDoubleFromExpression("value", player)
     }
 }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderGreaterThan.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderGreaterThan.kt
@@ -25,7 +25,7 @@ object ConditionPlaceholderGreaterThan : Condition<NoCompileData>("placeholder_g
     ): Boolean {
         val player = dispatcher.get<Player>()
 
-        return (config.getDoubleFromExpression("placeholder", placeholderContext(player = player))
-                ) >= config.getDoubleFromExpression("value", player)
+        return (config.getDoubleFromExpression("placeholder", placeholderContext(player = player))) >=
+                config.getDoubleFromExpression("value", placeholderContext(player = player))
     }
 }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderLessThan.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderLessThan.kt
@@ -25,7 +25,7 @@ object ConditionPlaceholderLessThan : Condition<NoCompileData>("placeholder_less
     ): Boolean {
         val player = dispatcher.get<Player>()
 
-        return (config.getDoubleFromExpression("placeholder", placeholderContext(player = player))
-                ) < config.getDoubleFromExpression("value", player)
+        return (config.getDoubleFromExpression("placeholder", placeholderContext(player = player))) <
+                config.getDoubleFromExpression("value", placeholderContext(player = player))
     }
 }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderLessThan.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionPlaceholderLessThan.kt
@@ -25,7 +25,7 @@ object ConditionPlaceholderLessThan : Condition<NoCompileData>("placeholder_less
     ): Boolean {
         val player = dispatcher.get<Player>()
 
-        return (config.getFormattedString("placeholder", placeholderContext(player = player))
-            .toDoubleOrNull() ?: 0.0) < config.getDoubleFromExpression("value", player)
+        return (config.getDoubleFromExpression("placeholder", placeholderContext(player = player))
+                ) < config.getDoubleFromExpression("value", player)
     }
 }


### PR DESCRIPTION
Firstly, in the wiki (https://plugins.auxilor.io/effects/all-conditions/placeholder_greater_than) it says "greater than or equal" for `placeholder_higher_than` condition, which it's not actually the case as the operator is `>` and not `>=`.
Secondly, it should be a mathematical evaluation, not a formatted string followed by a conversion to double. Probably this is why in most cases, those 2 conditions don't work accordingly with placeholders, if any space, or character, or whatever is present.
Thirdly, allow placeholders to be evaluated in both `placeholder` and `value` arguments.