### PR TITLE
Fixed weighted chains

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/Weighted.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/Weighted.kt
@@ -22,8 +22,12 @@ open class WeightedList<T : Weighted>(
         }
 
         val totalWeight = this.sumOf { it.weight }
-        val random = Math.random() * totalWeight
+        if (totalWeight == 0.0) {
+            val randomIndex = (Math.random() * this.size).toInt()
+            return this[randomIndex]
+        }
 
+        val random = Math.random() * totalWeight
         var current = 0.0
         for (item in this) {
             current += item.weight


### PR DESCRIPTION
This fixes two issues with weighted chains in the latest version:

1. If you don't specify a weight.. "List is Empty". If none is specified then it should be equal weights. This is resolved.
2. Weights don't actually do anything... I had a list of 10,20,50 and 90. They all still came randomly. This also fixed this.

Feel free to tidy it up, but this is working for me currrently.