### PR TITLE
fixed additional blank line

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectBroadcast.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectBroadcast.kt
@@ -23,6 +23,7 @@ object EffectBroadcast : Effect<NoCompileData>("broadcast") {
         val messages = config.getStrings("messages", "message")
             .map { it.replace("%player%", data.player?.name ?: "%player%") }
             .formatEco(config.toPlaceholderContext(data))
+            .dropLastWhile { it.isEmpty() }
 
         for (message in messages) {
             @Suppress("DEPRECATION")

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectRunCommand.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectRunCommand.kt
@@ -27,6 +27,7 @@ object EffectRunCommand : Effect<NoCompileData>("run_command") {
             .map { it.replace("%player%", player?.name ?: "%player")
             it.replace("%victim%", victim?.name ?: "")}
             .map { it.translatePlaceholders(config.toPlaceholderContext(data)) }
+            .dropLastWhile { it.isEmpty() }
 
         commands.forEach {
             Bukkit.getServer().dispatchCommand(

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectRunPlayerCommand.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectRunPlayerCommand.kt
@@ -28,6 +28,7 @@ object EffectRunPlayerCommand : Effect<NoCompileData>("run_player_command") {
             .map { it.replace("%player%", player.name)
                 it.replace("%victim%", victim?.name ?: "")}
             .map { it.translatePlaceholders(config.toPlaceholderContext(data)) }
+            .dropLastWhile { it.isEmpty() }
 
         val isOp = player.isOp
 

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSendMessage.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSendMessage.kt
@@ -27,6 +27,7 @@ object EffectSendMessage : Effect<NoCompileData>("send_message") {
         val messages = config.getStrings("messages", "message")
             .map { it.replace("%player%", player.name) }
             .formatEco(config.toPlaceholderContext(data))
+            .dropLastWhile { it.isEmpty() }
 
         val actionBar = config.getBool("action_bar")
 

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/EffectSendMinimessage.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/paper/impl/EffectSendMinimessage.kt
@@ -28,6 +28,7 @@ object EffectSendMinimessage : Effect<NoCompileData>("send_minimessage") {
         val messages = config.getStrings("messages", "message")
             .map { it.replace("%player%", player.name) }
             .map { PlaceholderManager.translatePlaceholders(it, config.toPlaceholderContext(data)) }
+            .dropLastWhile { it.isEmpty() }
             .map { miniMessage.deserialize(it) }
 
         val actionBar = config.getBool("action_bar")


### PR DESCRIPTION
Currently, 'send_message' & 'broadcast' add a blank line message at the end when using plural key (messages). The 'run_command' and 'run_player_command' also run a blank command on every trigger, which in some cases produces a libreforge error.

This PR fixes all of the above and it is now much cleaner to use.