### PR TITLE
Fix memory leak issue causing StackOverflowError

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDamageNearbyEntities.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDamageNearbyEntities.kt
@@ -12,8 +12,11 @@ import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
+import java.util.UUID
 
 object EffectDamageNearbyEntities : Effect<Collection<TestableEntity>>("damage_nearby_entities") {
+    private val damagedEntities = mutableSetOf<UUID>()
+
     override val parameters = setOf(
         TriggerParameter.LOCATION, TriggerParameter.PLAYER
     )
@@ -35,7 +38,7 @@ object EffectDamageNearbyEntities : Effect<Collection<TestableEntity>>("damage_n
         val damageSelf = config.getBoolOrNull("damage_self") ?: true
 
         for (entity in world.getNearbyEntities(location, radius, radius, radius)) {
-            if (entity.hasMetadata("ignore-nearby-damage")) {
+            if (entity.hasMetadata("ignore-nearby-damage") || damagedEntities.contains(entity.uniqueId)) {
                 continue
             }
 
@@ -60,12 +63,16 @@ object EffectDamageNearbyEntities : Effect<Collection<TestableEntity>>("damage_n
                 continue
             }
 
+            damagedEntities.add(entity.uniqueId)
+
             if (damageAsPlayer) {
                 entity.damage(damage, player)
             } else {
                 entity.damage(damage)
             }
         }
+
+        damagedEntities.clear()
 
         return true
     }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMeleeAttack.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMeleeAttack.kt
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
+import java.util.UUID
 
 object TriggerMeleeAttack : Trigger("melee_attack") {
     override val parameters = setOf(
@@ -19,6 +20,8 @@ object TriggerMeleeAttack : Trigger("melee_attack") {
         TriggerParameter.ITEM
     )
 
+    private val processedEvents = mutableSetOf<UUID>()
+
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageByEntityEvent) {
         val attacker = event.damager as? LivingEntity ?: return
@@ -27,6 +30,12 @@ object TriggerMeleeAttack : Trigger("melee_attack") {
         if (event.cause == EntityDamageEvent.DamageCause.THORNS) {
             return
         }
+
+        if (processedEvents.contains(event.entity.uniqueId)) {
+            return
+        }
+
+        processedEvents.add(event.entity.uniqueId)
 
         this.dispatch(
             attacker.toDispatcher(),
@@ -39,5 +48,7 @@ object TriggerMeleeAttack : Trigger("melee_attack") {
                 value = event.finalDamage
             )
         )
+
+        processedEvents.clear()
     }
 }


### PR DESCRIPTION
Fixes #186

Add checks to prevent recursive damage triggering and event handling to resolve memory leak issue.

* **EffectDamageNearbyEntities.kt**:
  - Add a `Set<UUID>` to track damaged entities.
  - Modify the `onTrigger` method to include a check for recursive damage.
  - Clear the `Set<UUID>` after processing all entities to avoid memory leaks.

* **TriggerMeleeAttack.kt**:
  - Add a `Set<UUID>` to track processed events.
  - Modify the `handle` method to include a check for recursive event handling.
  - Clear the `Set<UUID>` after processing the event to avoid memory leaks.

