### PR TITLE
WTF memory leak

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGlowNearbyBlocks.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGlowNearbyBlocks.kt
@@ -87,6 +87,7 @@ object EffectGlowNearbyBlocks : Effect<NoCompileData>("glow_nearby_blocks") {
             block.setMetadata("gnb-uuid", plugin.metadataValueFactory.create(shulker.uniqueId))
 
             plugin.scheduler.runLater(duration.toLong()) {
+                team.removeEntry(shulker.uniqueId.toString())
                 shulker.remove()
                 block.removeMetadata("gnb-uuid", plugin)
             }


### PR DESCRIPTION
The bug is adding a uuid to the team without deleting it. WTF packet team 25 MB
!
[bug](https://github.com/user-attachments/assets/097e2ba0-2a03-4151-8e7b-acdc66af7ccb)
