### PR TITLE
FIX: Trying to fix duplication drop issue

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/event/EditableDropEvent.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/event/EditableDropEvent.kt
@@ -122,7 +122,11 @@ class EditableBlockDropEvent(
         get() = event.items.map { it.itemStack }
 
     override val items: List<DropResult>
-        get() = originalItems.map { modifiers.modify(it) }
+        get(): List<DropResult> {
+            val res = originalItems.map { modifiers.modify(it) }
+            modifiers.clear()
+            return res
+        }
 
     override val dropLocation: Location
         get() = event.items.first().location


### PR DESCRIPTION
Explanation:

Every time, when I break blocks with active `multiply_drops` effect I get much more drops then expected.
For example, if I have this config:

```
effects:
  - id: multiply_drops # Bonus Multiplier
    args:
      chance: 100 
      multiplier: 2
    triggers:
      - block_item_drop
    filters:
      player_placed: true
      blocks:
        - "iron_ore"
```

I expect to get **2** raw iron, but instead, I get 512 + 2. 
Same issue when I use `fortune` argument.

I spent some time in debugger and found a solution - when EditableBlockDropEvent#items clear all modifiers after itemstack modification - all works as expected. But I don't think it's right, because I don't fully understand architecture. 