### PR TITLE
Prevent trigger on invulnerable entities in take damage

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/xiaomomiplugins/customfishing/impl/TriggerCatchFish.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/xiaomomiplugins/customfishing/impl/TriggerCatchFish.kt
@@ -12,13 +12,14 @@ object TriggerCatchFish : Trigger("catch_fish") {
     override val parameters = setOf(
         TriggerParameter.PLAYER,
         TriggerParameter.EVENT,
+        TriggerParameter.LOCATION,
         TriggerParameter.TEXT,
         TriggerParameter.ITEM
     )
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: FishingLootSpawnEvent) {
-        val player = event.player ?: return
+        val player = event.player
         val loot = event.loot.id() ?: return
         val location = event.location ?: return
         val entity = event.entity

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTakeDamage.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTakeDamage.kt
@@ -31,9 +31,13 @@ object TriggerTakeDamage : Trigger("take_damage") {
 
     @EventHandler(ignoreCancelled = true)
     fun handle(event: EntityDamageEvent) {
-        val victim = event.entity
+        val victim = event.entity as? LivingEntity ?: return
 
         if (event.cause in ignoredCauses) {
+            return
+        }
+
+        if (victim.noDamageTicks > 0) {
             return
         }
 
@@ -41,7 +45,7 @@ object TriggerTakeDamage : Trigger("take_damage") {
             victim.toDispatcher(),
             TriggerData(
                 player = victim as? Player,
-                victim = victim as? LivingEntity,
+                victim = victim,
                 event = event,
                 value = event.finalDamage
             )


### PR DESCRIPTION
Added a check to ensure the take_damage trigger only dispatches when the victim's noDamageTicks is zero, preventing the trigger from firing for entities that are currently invulnerable.

this fixes issues where the trigger infinitely fires when in lava or touching a cactus 