### PR TITLE
Add Sound Category as Configurable Option to Play Sound Effect

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectPlaySound.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectPlaySound.kt
@@ -9,6 +9,7 @@ import com.willfp.libreforge.getDoubleFromExpression
 import com.willfp.libreforge.getFormattedString
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.SoundCategory
 
 object EffectPlaySound : Effect<NoCompileData>("play_sound") {
     override val parameters = setOf(
@@ -28,7 +29,11 @@ object EffectPlaySound : Effect<NoCompileData>("play_sound") {
         val pitch = config.getDoubleFromExpression("pitch", data)
         val volume = config.getDoubleFromExpression("volume", data)
 
-        player.playSound(player.location, sound, volume.toFloat(), pitch.toFloat())
+        var categoryString = config.getStringOrNull("category")
+        if (categoryString == null) categoryString = "MASTER"
+        val category = SoundCategory.valueOf(categoryString.uppercase())
+
+        player.playSound(player.location, sound, category, volume.toFloat(), pitch.toFloat())
 
         return true
     }


### PR DESCRIPTION
This PR adds a `category` config option that allows users to put in their own category that's not MASTER. This is an optional config option and will default to MASTER when none is present, preserving existing behavior on servers while still adding now functionality to servers who wish to use it. 