### PR TITLE
Set cloud duration, according to the effect duration.

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnPotionCloud.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnPotionCloud.kt
@@ -42,6 +42,7 @@ object EffectSpawnPotionCloud : Effect<NoCompileData>("spawn_potion_cloud") {
         )
 
         cloud.source = data.player
+        cloud.duration = duration
 
         return true
     }


### PR DESCRIPTION
Currently the `spawn_potion_cloud` effect stays there permanently. 

This sets the duration of the cloud to that of the effects duration (unsure if there should be a separate value for cloud duration vs effect duration but for simplicity I'm keeping them the same).

Fixes bugs in default EcoEnchants configs where some enchants (ie: Contagion) will leave a permanent cloud that has to be `/kill`'d to go away.