### PR TITLE
Add "antigravity_projectile" effect, "trigger_heal" arg, "trident_hit" trigger

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
@@ -28,6 +28,7 @@ import com.willfp.libreforge.effects.impl.EffectAddPoints
 import com.willfp.libreforge.effects.impl.EffectAgeCrop
 import com.willfp.libreforge.effects.impl.EffectAllPlayers
 import com.willfp.libreforge.effects.impl.EffectAnimation
+import com.willfp.libreforge.effects.impl.EffectAntigravityProjectile
 import com.willfp.libreforge.effects.impl.EffectArmor
 import com.willfp.libreforge.effects.impl.EffectArmorToughness
 import com.willfp.libreforge.effects.impl.EffectArrowRing
@@ -495,6 +496,7 @@ object Effects : Registry<Effect<*>>() {
         register(EffectAddPoints)
         register(EffectAgeCrop)
         register(EffectAllPlayers)
+        register(EffectAntigravityProjectile)
         register(EffectAnimation)
         register(EffectArmor)
         register(EffectArmorToughness)

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAntigravityProjectile.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectAntigravityProjectile.kt
@@ -1,0 +1,38 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.core.map.listMap
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.effects.Identifiers
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.ProjectileLaunchEvent
+import java.util.UUID
+
+object EffectAntigravityProjectile : Effect<NoCompileData>("antigravity_projectile") {
+    private val players = listMap<UUID, UUID>()
+
+    override fun onEnable(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        identifiers: Identifiers,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ) {
+        players[dispatcher.uuid].add(identifiers.uuid)
+    }
+
+    override fun onDisable(dispatcher: Dispatcher<*>, identifiers: Identifiers, holder: ProvidedHolder) {
+        players[dispatcher.uuid].remove(identifiers.uuid)
+    }
+
+    @EventHandler
+    fun handle(event: ProjectileLaunchEvent) {
+        val player = event.entity.shooter as? Player ?: return
+        if (players[player.uniqueId].isEmpty()) return
+        event.entity.setGravity(false)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveHealth.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectGiveHealth.kt
@@ -8,6 +8,7 @@ import com.willfp.libreforge.getDoubleFromExpression
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.attribute.Attribute
+import org.bukkit.event.entity.EntityRegainHealthEvent
 
 object EffectGiveHealth : Effect<NoCompileData>("give_health") {
     override val parameters = setOf(
@@ -21,8 +22,19 @@ object EffectGiveHealth : Effect<NoCompileData>("give_health") {
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
         val player = data.player ?: return false
 
-        player.health = (player.health + config.getDoubleFromExpression("amount", data))
-            .coerceAtMost(player.getAttribute(Attribute.MAX_HEALTH)!!.value)
+        if (config.getBoolOrNull("trigger_heal") == true) {
+            val amount = config.getDoubleFromExpression("amount", data)
+            val event = EntityRegainHealthEvent(player, amount, EntityRegainHealthEvent.RegainReason.CUSTOM)
+            player.server.pluginManager.callEvent(event)
+
+            if (event.isCancelled) return false
+
+            player.health = (player.health + event.amount)
+                .coerceAtMost(player.getAttribute(Attribute.MAX_HEALTH)!!.value)
+        } else {
+            player.health = (player.health + config.getDoubleFromExpression("amount", data))
+                .coerceAtMost(player.getAttribute(Attribute.MAX_HEALTH)!!.value)
+        }
 
         return true
     }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/paper/PaperIntegration.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/paper/PaperIntegration.kt
@@ -20,6 +20,7 @@ import com.willfp.libreforge.integrations.paper.impl.TriggerTridentAttack
 import com.willfp.libreforge.integrations.paper.impl.TriggerUseFlowerPot
 import com.willfp.libreforge.integrations.paper.impl.TriggerVillagerTrade
 import com.willfp.libreforge.triggers.Triggers
+import com.willfp.libreforge.triggers.impl.TriggerTridentHit
 
 object PaperIntegration : LoadableIntegration {
     override fun load(plugin: EcoPlugin) {
@@ -38,6 +39,7 @@ object PaperIntegration : LoadableIntegration {
         Triggers.register(TriggerElytraBoost)
         Triggers.register(TriggerRenameEntity)
         Triggers.register(TriggerTridentAttack)
+        Triggers.register(TriggerTridentHit)
         Triggers.register(TriggerUseFlowerPot)
         Triggers.register(TriggerVillagerTrade)
     }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTridentHit.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerTridentHit.kt
@@ -1,0 +1,82 @@
+package com.willfp.libreforge.triggers.impl
+
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.holders
+import com.willfp.libreforge.plugin
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.entity.LivingEntity
+import org.bukkit.entity.Player
+import org.bukkit.entity.Trident
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.ProjectileHitEvent
+import org.bukkit.event.entity.ProjectileLaunchEvent
+
+private const val META_KEY = "libreforge_trident_hit_holders"
+
+object TriggerTridentHit : Trigger("trident_hit") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.VICTIM,
+        TriggerParameter.PROJECTILE,
+        TriggerParameter.LOCATION,
+        TriggerParameter.BLOCK,
+        TriggerParameter.EVENT,
+        TriggerParameter.VELOCITY
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun onProjectileLaunch(event: ProjectileLaunchEvent) {
+        val trident = event.entity as? Trident ?: return
+        val shooter = trident.shooter as? LivingEntity ?: return
+
+        trident.setMetadata(
+            META_KEY,
+            plugin.metadataValueFactory.create(shooter.toDispatcher().holders)
+        )
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: ProjectileHitEvent) {
+        val trident = event.entity as? Trident ?: return
+        val shooter = trident.shooter as? LivingEntity ?: return
+
+        @Suppress("UNCHECKED_CAST")
+        this.dispatch(
+            shooter.toDispatcher(),
+            TriggerData(
+                player = shooter as? Player,
+                projectile = trident,
+                location = trident.location,
+                block = event.hitBlock,
+                event = event,
+                velocity = trident.velocity
+            ),
+            forceHolders = trident.getMetadata(META_KEY).firstOrNull()?.value() as? Collection<ProvidedHolder>
+        )
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: EntityDamageByEntityEvent) {
+        val trident = event.damager as? Trident ?: return
+        val victim = event.entity as? LivingEntity ?: return
+        val shooter = trident.shooter as? LivingEntity ?: return
+
+        @Suppress("UNCHECKED_CAST")
+        this.dispatch(
+            shooter.toDispatcher(),
+            TriggerData(
+                player = shooter as? Player,
+                victim = victim,
+                location = trident.location,
+                event = event,
+                velocity = trident.velocity,
+                projectile = trident
+            ),
+            forceHolders = trident.getMetadata(META_KEY).firstOrNull()?.value() as? Collection<ProvidedHolder>
+        )
+    }
+}


### PR DESCRIPTION
- Adds a new antigravity_projectile effect (permanent, not triggered)
- Adds a new arg "trigger_heal" to the give_health effect, which fires the "heal" trigger
- Adds a new trigger "trident_hit" which similar to trident_attack to use the correct holders after a trident has left a players hand