### PR TITLE
chore: CI Optimisation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+﻿name: Build
 on:
   - push
   - pull_request

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,25 @@
-﻿name: Build
+name: Build
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.kt'
+      - '**/*.kts'
+  push:
+    branches:
+      - master
+    paths:
+      - '**/*.kt'
+      - '**/*.kts'
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Scoped build trigger to \`.kt\`/\`.kts\` file changes only (PR commits + master merges)
- Added concurrency group to cancel redundant in-progress runs on new commits
- Added \`permissions: contents: read\` to lock down token scope