### PR TITLE
Add pickup option for shot arrows

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShoot.kt
@@ -43,7 +43,14 @@ object EffectShoot : Effect<NoCompileData>("shoot") {
             }
 
             if (projectile is AbstractArrow) {
-                projectile.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
+                val pickupStatus = if (config.getBool("allow_pickup")) {
+                    AbstractArrow.PickupStatus.ALLOWED
+                } else {
+                    AbstractArrow.PickupStatus.DISALLOWED
+                }
+
+                projectile.pickupStatus = pickupStatus
+
             }
 
             if (fire) {

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectShootArrow.kt
@@ -31,7 +31,15 @@ object EffectShootArrow : Effect<NoCompileData>("shoot_arrow") {
                 arrow.teleportAsync(data.location)
             }
 
-            arrow.pickupStatus = AbstractArrow.PickupStatus.DISALLOWED
+            val pickupStatus = if (config.getBool("allow_pickup")) {
+                AbstractArrow.PickupStatus.ALLOWED
+            } else {
+                AbstractArrow.PickupStatus.DISALLOWED
+            }
+
+            arrow.pickupStatus = pickupStatus
+
+
             if (fire) {
                 arrow.fireTicks = Int.MAX_VALUE
             }


### PR DESCRIPTION
Adds an optional `allow_pickup` argument to `shoot_arrow` and `shoot`.

This lets configs choose whether arrows fired by these effects can be picked back up. The default behavior is unchanged, so existing configs still fire non-pickupable arrows unless they opt in.