### PR TITLE
feat: Player Dropped Filter [EcoHub-21]

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
@@ -18,6 +18,7 @@ import com.willfp.libreforge.configs.TagsYml
 import com.willfp.libreforge.configs.lrcdb.CommandLrcdb
 import com.willfp.libreforge.display.ItemFlagDisplay
 import com.willfp.libreforge.effects.Effects
+import com.willfp.libreforge.filters.DropProvenanceListener
 import com.willfp.libreforge.effects.arguments.custom.CustomEffectArguments
 import com.willfp.libreforge.effects.impl.bossbar.BossBarProgressPlaceholder
 import com.willfp.libreforge.integrations.auraskills.AuraSkillsIntegration
@@ -223,7 +224,8 @@ class LibreforgeSpigotPlugin : EcoPlugin() {
         val listeners = mutableListOf(
             EffectDataFixer,
             ItemRefreshListener,
-            EntityRefreshListener
+            EntityRefreshListener,
+            DropProvenanceListener,
         )
 
         if (Prerequisite.HAS_PAPER.isMet) {

--- a/core/common/src/main/kotlin/com/willfp/libreforge/filters/DropProvenanceListener.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/filters/DropProvenanceListener.kt
@@ -1,0 +1,49 @@
+package com.willfp.libreforge.filters
+
+import com.willfp.libreforge.plugin
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.ItemMergeEvent
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.event.player.PlayerDropItemEvent
+import org.bukkit.metadata.FixedMetadataValue
+
+object DropProvenanceListener : Listener {
+    const val DROPPER_KEY = "libreforge:dropper_uuid"
+
+    @EventHandler(ignoreCancelled = true)
+    fun onDrop(event: PlayerDropItemEvent) {
+        event.itemDrop.setMetadata(
+            DROPPER_KEY,
+            FixedMetadataValue(plugin, event.player.uniqueId.toString())
+        )
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun onDeath(event: PlayerDeathEvent) {
+        val player = event.entity
+        val world = player.world
+        val location = player.location
+        val uuid = player.uniqueId.toString()
+
+        val drops = event.drops.toList()
+        event.drops.clear()
+
+        for (stack in drops) {
+            val item = world.dropItemNaturally(location, stack)
+            item.setMetadata(DROPPER_KEY, FixedMetadataValue(plugin, uuid))
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun onMerge(event: ItemMergeEvent) {
+        val target = event.target
+        if (target.hasMetadata(DROPPER_KEY)) return
+
+        val source = event.entity
+        val sourceUuid = source.getMetadata(DROPPER_KEY)
+            .firstOrNull()?.asString() ?: return
+
+        target.setMetadata(DROPPER_KEY, FixedMetadataValue(plugin, sourceUuid))
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/filters/Filters.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/filters/Filters.kt
@@ -10,6 +10,7 @@ import com.willfp.libreforge.deprecationMessage
 import com.willfp.libreforge.filters.impl.FilterAboveHealthPercent
 import com.willfp.libreforge.filters.impl.FilterAdvancements
 import com.willfp.libreforge.filters.impl.FilterAltValueAbove
+import com.willfp.libreforge.filters.impl.FilterAnyPlayerDropped
 import com.willfp.libreforge.filters.impl.FilterAltValueBelow
 import com.willfp.libreforge.filters.impl.FilterAltValueEquals
 import com.willfp.libreforge.filters.impl.FilterBlocks
@@ -34,6 +35,7 @@ import com.willfp.libreforge.filters.impl.FilterItems
 import com.willfp.libreforge.filters.impl.FilterOnMaxHealth
 import com.willfp.libreforge.filters.impl.FilterOnlyBosses
 import com.willfp.libreforge.filters.impl.FilterOnlyNonBosses
+import com.willfp.libreforge.filters.impl.FilterPlayerDropped
 import com.willfp.libreforge.filters.impl.FilterPlayerName
 import com.willfp.libreforge.filters.impl.FilterPlayerPlaced
 import com.willfp.libreforge.filters.impl.FilterPotionEffect
@@ -103,6 +105,7 @@ object Filters : Registry<Filter<*, *>>() {
     init {
         register(FilterAboveHealthPercent)
         register(FilterAdvancements)
+        register(FilterAnyPlayerDropped)
         register(FilterAltValueAbove)
         register(FilterAltValueBelow)
         register(FilterAltValueEquals)
@@ -129,6 +132,7 @@ object Filters : Registry<Filter<*, *>>() {
         register(FilterOnlyBosses)
         register(FilterOnlyNonBosses)
         register(FilterPlayerName)
+        register(FilterPlayerDropped)
         register(FilterPlayerPlaced)
         register(FilterPotionEffect)
         register(FilterProjectiles)

--- a/core/common/src/main/kotlin/com/willfp/libreforge/filters/impl/FilterAnyPlayerDropped.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/filters/impl/FilterAnyPlayerDropped.kt
@@ -1,0 +1,19 @@
+package com.willfp.libreforge.filters.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.DropProvenanceListener
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+
+object FilterAnyPlayerDropped : Filter<NoCompileData, Boolean>("any_player_dropped") {
+    override fun getValue(config: Config, data: TriggerData?, key: String): Boolean {
+        return config.getBool(key)
+    }
+
+    override fun isMet(data: TriggerData, value: Boolean, compileData: NoCompileData): Boolean {
+        val item = data.itemEntity ?: return !value
+        val hasDropper = item.hasMetadata(DropProvenanceListener.DROPPER_KEY)
+        return hasDropper == value
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/filters/impl/FilterPlayerDropped.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/filters/impl/FilterPlayerDropped.kt
@@ -1,0 +1,22 @@
+package com.willfp.libreforge.filters.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.DropProvenanceListener
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+
+object FilterPlayerDropped : Filter<NoCompileData, Boolean>("player_dropped") {
+    override fun getValue(config: Config, data: TriggerData?, key: String): Boolean {
+        return config.getBool(key)
+    }
+
+    override fun isMet(data: TriggerData, value: Boolean, compileData: NoCompileData): Boolean {
+        val item = data.itemEntity ?: return !value
+        val player = data.player ?: return !value
+        val dropperUuid = item.getMetadata(DropProvenanceListener.DROPPER_KEY)
+            .firstOrNull()?.asString()
+        val isDroppedByThisPlayer = dropperUuid == player.uniqueId.toString()
+        return isDroppedByThisPlayer == value
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/TriggerData.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/TriggerData.kt
@@ -53,6 +53,9 @@ class TriggerData(
     var holder: ProvidedHolder = EmptyProvidedHolder
         internal set
 
+    var itemEntity: org.bukkit.entity.Item? = null
+        internal set
+
     /*
     This is a bodge inherited from v3, but it's the only real way to do this.
     Essentially, the player can get messed up by mutators, and that causes
@@ -142,6 +145,7 @@ class TriggerData(
         copy.holder = this.holder
         copy.originalPlayer = this.originalPlayer
         copy.inheritedTriggerPlaceholders = this.inheritedTriggerPlaceholders
+        copy.itemEntity = this.itemEntity
 
         return copy
     }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPickUpItem.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerPickUpItem.kt
@@ -20,14 +20,13 @@ object TriggerPickUpItem : Trigger("pick_up_item") {
     fun handle(event: EntityPickupItemEvent) {
         val entity = event.entity
 
-        this.dispatch(
-            entity.toDispatcher(),
-            TriggerData(
-                player = entity as? Player,
-                victim = entity,
-                item = event.item.itemStack,
-                value = event.item.itemStack.amount.toDouble()
-            )
-        )
+        val data = TriggerData(
+            player = entity as? Player,
+            victim = entity,
+            item = event.item.itemStack,
+            value = event.item.itemStack.amount.toDouble()
+        ).also { it.itemEntity = event.item }
+
+        this.dispatch(entity.toDispatcher(), data)
     }
 }


### PR DESCRIPTION
## Summary

Adds two new boolean filters for the `pick_up_item` trigger that let config authors distinguish player-dropped items from naturally spawned ones. This closes the self-loop exploit where collector-style skills/quests grant XP for items the player just dropped themselves.

**New filters:**
- `player_dropped: false`: blocks the trigger if the item was dropped by the picking-up player specifically
- `any_player_dropped: false`: blocks the trigger if the item was dropped by *any* player

**Implementation:**
- `DropProvenanceListener` tags dropped `Item` entities with a `libreforge:dropper_uuid` metadata key at drop time (including death drops), and propagates the tag when stacks merge on the ground
- `TriggerData` gains a new `itemEntity` property (post-construction, no binary-compat break) so filters can access the entity
- `TriggerPickUpItem` populates `itemEntity` on dispatch
- Both filters are registered in `Filters.kt` in alphabetical order

The metadata tag is intentionally transient... it lives only on the `Item` entity in memory and is cleared when the entity despawns, is picked up, or the server restarts.

## How to test in-game

Set up a `pick_up_item` effect chain with `send_message: "&aFired"` and test each scenario:

| Scenario | Filter | Expected |
|----------|--------|----------|
| Drop an item, pick it back up | `player_dropped: false` | Message does **not** appear |
| Player A drops, Player B picks up | `player_dropped: false` | Message **appears** |
| Player A drops, Player B picks up | `any_player_dropped: false` | Message does **not** appear |
| Kill a mob, pick up its loot | `any_player_dropped: false` | Message **appears** |
| Die, respawn, pick up your death drops | `player_dropped: false` | Message does **not** appear |
| Two stacks on the ground (one dropped by player, one natural) merge, then picked up | `any_player_dropped: false` | Message does **not** appear (tag propagated through merge) |
