### PR TITLE
fix: AuraSkills Autosmelt Compatability

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsIntegration.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsIntegration.kt
@@ -22,6 +22,7 @@ object AuraSkillsIntegration : LoadableIntegration {
         Conditions.register(ConditionHasSkillLevel)
         Effects.register(EffectSkillXpMultiplier)
         EffectArguments.register(ArgumentManaCost)
+        plugin.eventManager.registerListener(AuraSkillsLootDropListener)
     }
 
     override fun getPluginName(): String {

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsLootDropListener.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsLootDropListener.kt
@@ -1,6 +1,7 @@
 package com.willfp.libreforge.integrations.auraskills
 
 import com.willfp.eco.core.drops.DropQueue
+import com.willfp.eco.util.TelekinesisUtils
 import com.willfp.libreforge.toDispatcher
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.event.DropCause
@@ -58,9 +59,21 @@ object AuraSkillsLootDropListener : Listener {
             return
         }
 
+        val totalXP = dropResults.sumOf { it.xp }
+
+        if (TelekinesisUtils.testPlayer(event.player)) {
+            event.isCancelled = true
+            DropQueue(event.player)
+                .setLocation(event.location)
+                .addItems(dropResults.map { it.item })
+                .addXP(totalXP)
+                .forceTelekinesis()
+                .push()
+            return
+        }
+
         event.item = editableEvent.drops.first()
 
-        val totalXP = dropResults.sumOf { it.xp }
         if (totalXP > 0) {
             DropQueue(event.player)
                 .setLocation(event.location)

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsLootDropListener.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/auraskills/AuraSkillsLootDropListener.kt
@@ -1,0 +1,71 @@
+package com.willfp.libreforge.integrations.auraskills
+
+import com.willfp.eco.core.drops.DropQueue
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.event.DropCause
+import com.willfp.libreforge.triggers.event.DropContext
+import com.willfp.libreforge.triggers.event.EditableDropEvent
+import com.willfp.libreforge.triggers.impl.TriggerBlockItemDrop
+import dev.aurelium.auraskills.api.event.loot.LootDropEvent
+import org.bukkit.Material
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+
+private val MINING_CAUSES = setOf(
+    LootDropEvent.Cause.MINING_LUCK,
+    LootDropEvent.Cause.MINING_OTHER_LOOT
+)
+
+object AuraSkillsLootDropListener : Listener {
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    fun handle(event: LootDropEvent) {
+        if (event.cause !in MINING_CAUSES) return
+        if (event.entity != null) return
+
+        val originalItem = event.item
+        if (originalItem.type == Material.AIR || originalItem.amount <= 0) return
+
+        val editableEvent = EditableDropEvent(
+            initialDrops = listOf(originalItem),
+            cause = DropCause.BLOCK,
+            context = DropContext(
+                player = event.player,
+                block = null,
+                tool = event.player.inventory.itemInMainHand
+            ),
+            dropLocation = event.location,
+            cancellable = event
+        )
+
+        TriggerBlockItemDrop.dispatch(
+            event.player.toDispatcher(),
+            TriggerData(
+                player = event.player,
+                block = null,
+                location = event.location,
+                event = editableEvent,
+                item = null,
+                value = originalItem.amount.toDouble()
+            )
+        )
+
+        val dropResults = editableEvent.items
+
+        if (editableEvent.drops.isEmpty()) {
+            event.isCancelled = true
+            return
+        }
+
+        event.item = editableEvent.drops.first()
+
+        val totalXP = dropResults.sumOf { it.xp }
+        if (totalXP > 0) {
+            DropQueue(event.player)
+                .setLocation(event.location)
+                .addXP(totalXP)
+                .push()
+        }
+    }
+}


### PR DESCRIPTION
**Summary**

AuraSkills' bonus ore drops (Lucky Miner etc.) are spawned via `world.dropItem()` outside libreforge's `BlockDropItemEvent` pipeline, so effects like `autosmelt` and `multiply_drops` never ran on them... resulting in raw ore and ingots dropping side-by-side.

This PR adds `AuraSkillsLootDropListener`, a Bukkit listener inside the existing AuraSkills integration that intercepts `LootDropEvent` for mining causes (`MINING_LUCK`, `MINING_OTHER_LOOT`), wraps the bonus drop in an `EditableDropEvent`, and dispatches it through `TriggerBlockItemDrop`. All configured `block_item_drop` effects (autosmelt, multiply_drops, etc.) should now apply transparently to AuraSkills bonus drops with zero user config changes required.

**Testing**

- Mine iron ore with an item granting `autosmelt` under `block_item_drop`, with AuraSkills Lucky Miner triggering a bonus drop → both the vanilla drop and the bonus drop should be iron ingots (no raw iron)
- Mine a non-smeltable block (e.g. cobblestone) with Lucky Miner → bonus drop is unchanged (autosmelt is a no-op)
- Configure `multiply_drops` under `block_item_drop` → AuraSkills bonus drops are multiplied correctly
- Mine without Lucky Miner triggering → no regression in vanilla autosmelt behaviour
- Mine with EcoSkills also installed → listener is not registered (EcoSkills short-circuit in `AuraSkillsIntegration` still fires), no double-processing
- Configure an effect that cancels the drop → `LootDropEvent` is cancelled and no item drops (no ghost item left behind)