### PR TITLE
fix: update attribute handling to support new key formats

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/EffectDataFixer.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/EffectDataFixer.kt
@@ -1,7 +1,6 @@
 package com.willfp.libreforge
 
 import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent
-import com.willfp.libreforge.effects.Effects
 import org.bukkit.Registry
 import org.bukkit.attribute.Attribute
 import org.bukkit.entity.Player
@@ -44,12 +43,15 @@ object EffectDataFixer : Listener {
     }
 
     private fun Player.fixAttributes() {
-        val effectIds = Effects.values().map { it.id }.toSet()
-
         for (attribute in Registry.ATTRIBUTE) {
             val inst = this.getAttribute(attribute) ?: continue
-            for (mod in inst.modifiers) {
-                if (mod.name.startsWith("libreforge") || effectIds.any { mod.name.startsWith(it) }) {
+            for (mod in inst.modifiers.toList()) {
+                val key = mod.key
+                // lf_ prefix = new format; bare digits_digits = old format pre-fix
+                if (key.namespace == "eco" && (
+                    key.key.startsWith("lf_") ||
+                    key.key.matches(Regex("\\d+_\\d+"))
+                )) {
                     inst.removeModifier(mod)
                 }
             }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/Identifers.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/Identifers.kt
@@ -20,7 +20,7 @@ class IdentifierFactory(
         UUID.nameUUIDFromBytes("$uuid$offset".toByteArray())
 
     private fun makeKey(offset: Int) =
-        NamespacedKeyUtils.createEcoKey("${abs(uuid.hashCode())}_$offset")
+        NamespacedKeyUtils.createEcoKey("lf_${abs(uuid.hashCode())}_$offset")
 
     override fun toString(): String {
         return "IdentifierFactory(uuid=$uuid)"


### PR DESCRIPTION
fixAttributes() runs on join/quit as a safety net to strip stale libreforge attribute modifiers off the player.

Old code matched by name (mod.name.startsWith("libreforge")), but modifiers are created with only a NamespacedKey — no name string — so getName() never returned "libreforge:...". Safety net never fired. Stale modifiers (e.g. +6 HP from a removed talisman) survived forever.

New code matches by key (key.namespace == "eco" && key.key.startsWith("lf_")). Reliable. Also catches old-format keys (\d+_\d+) for backward compat.

Identifers.kt adds the lf_ prefix so future modifiers are unambiguously identifiable as libreforge-owned.