### PR TITLE
feat: Eco in Gradle Properties

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,7 +3,7 @@ version = rootProject.version
 
 subprojects {
     dependencies {
-        compileOnly("com.willfp:eco:7.6.0")
+        compileOnly("com.willfp:eco:${findProperty("eco-version")}")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 version = 5.5.0
 kotlin.code.style = official
 org.gradle.parallel=true
+eco-version=7.6.0

--- a/loader/build.gradle.kts
+++ b/loader/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     compileOnly(project(":core:common"))
 
-    compileOnly("com.willfp:eco:7.6.0")
+    compileOnly("com.willfp:eco:${findProperty("eco-version")}")
     compileOnly("io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT")
 }
 


### PR DESCRIPTION
Moves eco dependency version from hardcoded value in `build.gradle.kts` to `gradle.properties` as `eco-version`, following the same pattern as `libreforge-version`.