### PR TITLE
feat: Move Item Trigger

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/Triggers.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/Triggers.kt
@@ -76,6 +76,7 @@ import com.willfp.libreforge.triggers.impl.TriggerMineBlock
 import com.willfp.libreforge.triggers.impl.TriggerMineBlockCascade
 import com.willfp.libreforge.triggers.impl.TriggerMineBlockProgress
 import com.willfp.libreforge.triggers.impl.TriggerMove
+import com.willfp.libreforge.triggers.impl.TriggerMoveItem
 import com.willfp.libreforge.triggers.impl.TriggerNoteBlockPlay
 import com.willfp.libreforge.triggers.impl.TriggerPickUpItem
 import com.willfp.libreforge.triggers.impl.TriggerPlaceBlock
@@ -225,6 +226,7 @@ object Triggers : Registry<Trigger>() {
         register(TriggerMineBlockCascade)
         register(TriggerMineBlockProgress)
         register(TriggerMove)
+        register(TriggerMoveItem)
         register(TriggerNoteBlockPlay)
         register(TriggerPickUpItem)
         register(TriggerPlaceBlock)

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMoveItem.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMoveItem.kt
@@ -1,0 +1,33 @@
+package com.willfp.libreforge.triggers.impl
+
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.inventory.InventoryClickEvent
+
+object TriggerMoveItem : Trigger("move_item") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.ITEM,
+        TriggerParameter.EVENT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: InventoryClickEvent) {
+        val player = event.whoClicked as? Player ?: return
+        val item = event.currentItem ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                item = item,
+                event = event,
+                value = item.amount.toDouble()
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Issue
Closes #52

## Testing
- [x] Trigger with filter 'items' locked to diamond works on item move in inventory

## Description
Added new Trigger for 'Item Moving' as requested by @Lariesse