### PR TITLE
feat: New Effects & Triggers

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/conditions/Conditions.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/conditions/Conditions.kt
@@ -59,6 +59,7 @@ import com.willfp.libreforge.conditions.impl.ConditionItemPointsAbove
 import com.willfp.libreforge.conditions.impl.ConditionItemPointsBelow
 import com.willfp.libreforge.conditions.impl.ConditionItemPointsEqual
 import com.willfp.libreforge.conditions.impl.ConditionLightLevelBelow
+import com.willfp.libreforge.conditions.impl.ConditionNearBlock
 import com.willfp.libreforge.conditions.impl.ConditionNearEntity
 import com.willfp.libreforge.conditions.impl.ConditionOnFire
 import com.willfp.libreforge.conditions.impl.ConditionOnGround
@@ -184,6 +185,7 @@ object Conditions : Registry<Condition<*>>() {
         register(ConditionIsSprinting)
         register(ConditionIsStorm)
         register(ConditionIsSwimming)
+        register(ConditionNearBlock)
         register(ConditionNearEntity)
         register(ConditionOnFire)
         register(ConditionPlaceholderContains)

--- a/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionNearBlock.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/conditions/impl/ConditionNearBlock.kt
@@ -1,0 +1,45 @@
+package com.willfp.libreforge.conditions.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.Material
+import org.bukkit.entity.LivingEntity
+
+object ConditionNearBlock : Condition<NoCompileData>("near_block") {
+    override val arguments = arguments {
+        require("block", "You must specify the block type!")
+        require("radius", "You must specify the radius!")
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val entity = dispatcher.get<LivingEntity>() ?: return false
+        val location = entity.location
+        val radius = config.getInt("radius")
+        val targetMaterial = Material.matchMaterial(config.getString("block").uppercase()) ?: return false
+
+        for (x in -radius..radius) {
+            for (y in -radius..radius) {
+                for (z in -radius..radius) {
+                    val block = location.world.getBlockAt(
+                        location.blockX + x,
+                        location.blockY + y,
+                        location.blockZ + z
+                    )
+                    if (block.type == targetMaterial) return true
+                }
+            }
+        }
+
+        return false
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/Effects.kt
@@ -178,6 +178,9 @@ import com.willfp.libreforge.effects.impl.EffectSetGlowing
 import com.willfp.libreforge.effects.impl.EffectSetGlobalPoints
 import com.willfp.libreforge.effects.impl.EffectSetItemData
 import com.willfp.libreforge.effects.impl.EffectSetItemPoints
+import com.willfp.libreforge.effects.impl.EffectSetNearbyBlocks
+import com.willfp.libreforge.effects.impl.EffectSetPlayerTime
+import com.willfp.libreforge.effects.impl.EffectSetPlayerWeather
 import com.willfp.libreforge.effects.impl.EffectSetPoints
 import com.willfp.libreforge.effects.impl.EffectSetSaturation
 import com.willfp.libreforge.effects.impl.EffectSetUnbreakable
@@ -190,6 +193,7 @@ import com.willfp.libreforge.effects.impl.EffectShuffleHotbar
 import com.willfp.libreforge.effects.impl.EffectSmite
 import com.willfp.libreforge.effects.impl.EffectSneakingSpeedMultiplier
 import com.willfp.libreforge.effects.impl.EffectSpawnEntity
+import com.willfp.libreforge.effects.impl.EffectSpawnFallingBlock
 import com.willfp.libreforge.effects.impl.EffectSpawnMobs
 import com.willfp.libreforge.effects.impl.EffectShockwave
 import com.willfp.libreforge.effects.impl.EffectSortInventory
@@ -660,6 +664,9 @@ object Effects : Registry<Effect<*>>() {
         register(EffectSetGlobalPoints)
         register(EffectSetItemData)
         register(EffectSetItemPoints)
+        register(EffectSetNearbyBlocks)
+        register(EffectSetPlayerTime)
+        register(EffectSetPlayerWeather)
         register(EffectSetPoints)
         register(EffectSetSaturation)
         register(EffectSetUnbreakable)
@@ -671,6 +678,7 @@ object Effects : Registry<Effect<*>>() {
         register(EffectShuffleHotbar)
         register(EffectSmite)
         register(EffectSpawnEntity)
+        register(EffectSpawnFallingBlock)
         register(EffectSpawnMobs)
         register(EffectShockwave)
         register(EffectSortInventory)

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetNearbyBlocks.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetNearbyBlocks.kt
@@ -1,0 +1,42 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.blocks.Blocks
+import com.willfp.eco.core.blocks.TestableBlock
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ViolationContext
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getIntFromExpression
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectSetNearbyBlocks : Effect<TestableBlock>("set_nearby_blocks") {
+    override val parameters = setOf(
+        TriggerParameter.LOCATION
+    )
+
+    override val arguments = arguments {
+        require("block", "You must specify the block type!")
+        require("radius", "You must specify the radius!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: TestableBlock): Boolean {
+        val location = data.location ?: return false
+        val radius = config.getIntFromExpression("radius", data)
+
+        for (x in -radius..radius) {
+            for (y in -radius..radius) {
+                for (z in -radius..radius) {
+                    val blockLocation = location.clone().add(x.toDouble(), y.toDouble(), z.toDouble())
+                    compileData.place(blockLocation)
+                }
+            }
+        }
+
+        return true
+    }
+
+    override fun makeCompileData(config: Config, context: ViolationContext): TestableBlock {
+        return Blocks.lookup(config.getString("block"))
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetPlayerTime.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetPlayerTime.kt
@@ -1,0 +1,33 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectSetPlayerTime : Effect<NoCompileData>("set_player_time") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require("time", "You must specify the time (ticks: 0=dawn, 6000=noon, 12000=dusk, 18000=midnight)!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+
+        if (config.getBool("reset")) {
+            player.resetPlayerTime()
+            return true
+        }
+
+        val time = config.getInt("time").toLong()
+        val relative = config.getBool("relative")
+
+        player.setPlayerTime(time, relative)
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetPlayerWeather.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSetPlayerWeather.kt
@@ -1,0 +1,37 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.WeatherType
+
+object EffectSetPlayerWeather : Effect<NoCompileData>("set_player_weather") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require("weather", "You must specify the weather type (clear or downfall)!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+
+        if (config.getBool("reset")) {
+            player.resetPlayerWeather()
+            return true
+        }
+
+        val weatherType = when (config.getString("weather").lowercase()) {
+            "clear" -> WeatherType.CLEAR
+            "downfall", "rain", "storm" -> WeatherType.DOWNFALL
+            else -> return false
+        }
+
+        player.setPlayerWeather(weatherType)
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnFallingBlock.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnFallingBlock.kt
@@ -1,0 +1,35 @@
+package com.willfp.libreforge.effects.impl
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getIntFromExpression
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.Material
+
+object EffectSpawnFallingBlock : Effect<NoCompileData>("spawn_falling_block") {
+    override val parameters = setOf(
+        TriggerParameter.LOCATION
+    )
+
+    override val arguments = arguments {
+        require("block", "You must specify the block material!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val location = data.location ?: return false
+        val material = Material.matchMaterial(config.getString("block").uppercase()) ?: return false
+
+        if (!material.isBlock) return false
+
+        val height = config.getIntFromExpression("height", data).coerceAtLeast(0)
+        val spawnLocation = location.clone().add(0.0, height.toDouble(), 0.0)
+
+        @Suppress("DEPRECATION")
+        spawnLocation.world.spawnFallingBlock(spawnLocation, material, 0.toByte())
+
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/Triggers.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/Triggers.kt
@@ -95,6 +95,7 @@ import com.willfp.libreforge.triggers.impl.TriggerShieldBlock
 import com.willfp.libreforge.triggers.impl.TriggerShootBow
 import com.willfp.libreforge.triggers.impl.TriggerSmelt
 import com.willfp.libreforge.triggers.impl.TriggerSmithItem
+import com.willfp.libreforge.triggers.impl.TriggerStartSwimming
 import com.willfp.libreforge.triggers.impl.TriggerSwapHands
 import com.willfp.libreforge.triggers.impl.TriggerTakeDamage
 import com.willfp.libreforge.triggers.impl.TriggerTakeEntityDamage
@@ -245,6 +246,7 @@ object Triggers : Registry<Trigger>() {
         register(TriggerShootBow)
         register(TriggerSmithItem)
         register(TriggerSmelt)
+        register(TriggerStartSwimming)
         register(TriggerSwapHands)
         register(TriggerTameAnimal)
         register(TriggerTeleport)

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerStartSwimming.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerStartSwimming.kt
@@ -1,0 +1,30 @@
+package com.willfp.libreforge.triggers.impl
+
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.EntityToggleSwimEvent
+
+object TriggerStartSwimming : Trigger("start_swimming") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: EntityToggleSwimEvent) {
+        if (!event.isSwimming) return
+        val player = event.entity as? Player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Issue
Closes #61

## Description
- Created `EffectSpawnFallingBlock.kt`: spawns a falling block at a configurable height above the trigger location
- Created `EffectSetNearbyBlocks.kt`: sets all blocks within a radius to a given block type
- Created `EffectSetPlayerWeather.kt`: sets or resets a player's personal weather override
- Created `EffectSetPlayerTime.kt`: sets or resets a player's personal time override
- Created `ConditionNearBlock.kt`: checks if a player is within a radius of a given block material
- Created `TriggerStartSwimming.kt`: fires when a player starts swimming

## Testing

### Player Time Effect
<img width="2559" height="1393" alt="{25578BBA-7752-4F39-A1DB-77F7A44FEA35}" src="https://github.com/user-attachments/assets/f680964f-9357-4bde-9262-0d379241574b" />

### Player Weather Effect
<img width="2560" height="1391" alt="{7154F662-3642-4604-8196-0C287D30F59F}" src="https://github.com/user-attachments/assets/14e5069a-70be-4373-867f-a1a2c80a10f0" />

### Swimming Trigger
<img width="1278" height="1392" alt="{84C4FAB9-85B1-4086-BA70-A7F0776C512A}" src="https://github.com/user-attachments/assets/bc2d21c2-d408-46a4-ae4f-f4e729d7876b" />

### Set Nearby Blocks Effect
<img width="1277" height="1393" alt="{D4A6A424-2873-4AFE-9FC2-9DB8535E7A2D}" src="https://github.com/user-attachments/assets/c400aa16-3185-4967-b992-a685e2f2dc77" />

### Near Block Condition
<img width="1279" height="1391" alt="{F77FBB0E-3991-4264-B453-8593B9F3C85C}" src="https://github.com/user-attachments/assets/04e75939-e5c7-40a4-b315-45e2a6b2df05" />

### Spawn Falling Block Effect
<img width="1282" height="1390" alt="{663578C1-A2DC-4677-B129-03A3F7B1668F}" src="https://github.com/user-attachments/assets/378dbc04-749d-45e7-b3b4-7f51e528d430" />
