### PR TITLE
feat: Owned Entities

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnEntity.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnEntity.kt
@@ -8,6 +8,7 @@ import com.willfp.libreforge.arguments
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.entity.Tameable
 
 object EffectSpawnEntity : Effect<TestableEntity>("spawn_entity") {
     override val parameters = setOf(
@@ -20,7 +21,11 @@ object EffectSpawnEntity : Effect<TestableEntity>("spawn_entity") {
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: TestableEntity): Boolean {
         val location = data.location ?: return false
-        compileData.spawn(location)
+        val spawned = compileData.spawn(location)
+
+        if (config.getBool("owner") && spawned is Tameable) {
+            spawned.owner = data.player
+        }
 
         return true
     }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnMobs.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectSpawnMobs.kt
@@ -15,6 +15,7 @@ import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.attribute.Attribute
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Mob
+import org.bukkit.entity.Tameable
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.entity.EntityDeathEvent
@@ -74,6 +75,10 @@ object EffectSpawnMobs : Effect<TestableEntity>("spawn_mobs") {
             }
 
             mob.health = health
+
+            if (config.getBool("owner") && mob is Tameable) {
+                mob.owner = player
+            }
 
             plugin.scheduler.runLater(ticksToLive.toLong()) { mob.remove() }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version = 5.6.0
 kotlin.code.style = official
 org.gradle.parallel=true
-eco-version=7.6.0
+eco-version=7.6.4


### PR DESCRIPTION
## Issue
Closes #24

## Description
Adds 'owner' as optional arg to entity spawning effects.

## Testing
- [x] Tamed filter
- [x] Spawn entity owner
- [x] Spawn mobs owner

## Related PR(s)
https://github.com/Auxilor/eco/pull/533