### PR TITLE
fix: Bow / Melee attack as Monitor.

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBowAttack.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerBowAttack.kt
@@ -9,6 +9,7 @@ import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 import org.bukkit.entity.Trident
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 
 object TriggerBowAttack : Trigger("bow_attack") {
@@ -21,7 +22,7 @@ object TriggerBowAttack : Trigger("bow_attack") {
         TriggerParameter.PROJECTILE
     )
     
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     fun handle(event: EntityDamageByEntityEvent) {
         val arrow = event.damager
         val victim = event.entity as? LivingEntity ?: return

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMeleeAttack.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMeleeAttack.kt
@@ -7,6 +7,7 @@ import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import java.util.UUID
@@ -22,7 +23,7 @@ object TriggerMeleeAttack : Trigger("melee_attack") {
 
     private val processedEvents = mutableSetOf<UUID>()
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     fun handle(event: EntityDamageByEntityEvent) {
         val attacker = event.damager as? LivingEntity ?: return
         val victim = event.entity as? LivingEntity ?: return


### PR DESCRIPTION
## Issue
Closes #115

## Description
Marked events for Melee attack and Bow attack triggers as `Monitor`.

## Testing
- [x] Tested Attack trigger with modify damage (5x) with wooden sword
- [x] Tested Attack trigger with cancel event with stone sword
- [x] Tested Bow trigger with modify damage (5x) with bow
- [x] Tested Bow trigger with cancel event with crossbow