### PR TITLE
feat: added use_blockface arg to mine_x effects [EcoHub-4]

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDrill.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDrill.kt
@@ -4,7 +4,6 @@ import com.willfp.eco.core.blocks.Blocks
 import com.willfp.eco.core.blocks.matches
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.integrations.antigrief.AntigriefManager
-import com.willfp.eco.util.VectorUtils
 import com.willfp.libreforge.ArgType
 import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.arguments
@@ -59,6 +58,14 @@ object EffectDrill : MineBlockEffect<NoCompileData>("drill") {
             description = "These block types will never be broken by the drill.",
             type = ArgType.BLOCK_LIST
         )
+        optional(
+            "use_blockface",
+            description = "Whether to drill into the face of the block the player is looking at, " +
+                    "rather than in their look direction. Falls back to the look direction if the " +
+                    "player isn't looking at the trigger block.",
+            type = ArgType.BOOLEAN,
+            default = "false"
+        )
     }
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
@@ -79,9 +86,11 @@ object EffectDrill : MineBlockEffect<NoCompileData>("drill") {
 
         val blocks = mutableSetOf<Block>()
 
+        val forwardAxis = resolveForwardAxis(config, player, block)
+
         for (i in 1..amount) {
-            val simplified = VectorUtils.simplifyVector(player.location.direction.normalize()).multiply(i)
-            val toBreak = block.world.getBlockAt(block.location.clone().add(simplified))
+            val offset = forwardAxis.clone().multiply(i)
+            val toBreak = block.world.getBlockAt(block.location.clone().add(offset))
 
             if (blacklist.matches(toBreak)) {
                 continue

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadius.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadius.kt
@@ -13,9 +13,12 @@ import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.Material
 import org.bukkit.block.Block
+import org.bukkit.entity.Player
+import kotlin.math.abs
 
 object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
-    override val description = "Mines all blocks in a cube radius around the triggered block."
+    override val description = "Mines all blocks in a cube radius around the triggered block, " +
+            "or in flat layers facing the player if depth is set."
     override val categories = setOf("world")
 
     override val parameters = setOf(
@@ -31,6 +34,14 @@ object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
             example = "2 + %level% / 20"
         )
         optional(
+            "depth",
+            description = "How many layers deep to mine, measured from the triggered block in the " +
+                    "direction the player is facing. If omitted, a full cube is mined instead. " +
+                    "Set this to 1 to mine a single flat layer. Supports expressions.",
+            type = ArgType.EXPRESSION,
+            example = "1"
+        )
+        optional(
             "prevent_trigger",
             description = "Whether breaking these blocks should prevent triggering further effects.",
             type = ArgType.BOOLEAN,
@@ -39,6 +50,12 @@ object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
         optional(
             "disable_on_sneak",
             description = "Whether the effect should be disabled while the player is sneaking.",
+            type = ArgType.BOOLEAN,
+            default = "false"
+        )
+        optional(
+            "no_corners",
+            description = "Whether corner blocks at the edge of the radius should be excluded.",
             type = ArgType.BOOLEAN,
             default = "false"
         )
@@ -60,6 +77,15 @@ object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
             type = ArgType.BOOLEAN,
             default = "true"
         )
+        optional(
+            "use_blockface",
+            description = "Whether to measure depth from the face of the block the player is " +
+                    "looking at, rather than from their look direction. Falls back to the look " +
+                    "direction if the player isn't looking at the triggered block. Only has an " +
+                    "effect when depth is set.",
+            type = ArgType.BOOLEAN,
+            default = "false"
+        )
     }
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
@@ -77,7 +103,67 @@ object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
         val whitelist = config.getStringsOrNull("whitelist")?.map { Blocks.lookup(it) }
         val blacklist = config.getStrings("blacklisted_blocks").map { Blocks.lookup(it) }
 
+        val noCorners = config.getBool("no_corners")
+
+        val candidates = if (config.has("depth")) {
+            val depth = config.getIntFromExpression("depth", data).coerceAtLeast(1)
+            layeredCandidates(config, player, block, radius, depth, noCorners)
+        } else {
+            cubeCandidates(block, radius, noCorners)
+        }
+
         val blocks = mutableSetOf<Block>()
+
+        for (toBreak in candidates) {
+            if (toBreak.location.blockY !in block.world.minHeight..block.world.maxHeight) {
+                continue
+            }
+
+            if (blacklist.matches(toBreak)) {
+                continue
+            }
+
+            if (whitelist != null) {
+                if (!whitelist.matches(toBreak)) {
+                    continue
+                }
+            }
+
+            if (config.getBoolOrNull("check_hardness") != false) {
+                if (Blocks.hardness(toBreak) > Blocks.hardness(block)) {
+                    continue
+                }
+            }
+
+            if (Blocks.hardness(toBreak) < 0) {
+                continue
+            }
+
+            if (toBreak.type == Material.AIR) {
+                continue
+            }
+
+            if (!AntigriefManager.canBreakBlock(player, toBreak)) {
+                continue
+            }
+
+            blocks.add(toBreak)
+        }
+
+        player.breakBlocksSafely(blocks, preventTriggers)
+
+        return true
+    }
+
+    /**
+     * Every block in a cube of [radius] around [block], excluding the block itself.
+     */
+    private fun cubeCandidates(
+        block: Block,
+        radius: Int,
+        noCorners: Boolean
+    ): List<Block> {
+        val candidates = mutableListOf<Block>()
 
         for (x in (-radius..radius)) {
             for (y in (-radius..radius)) {
@@ -86,49 +172,67 @@ object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
                         continue
                     }
 
-                    val toBreak = block.world.getBlockAt(
+                    if (noCorners && isCorner(radius, x, y, z)) {
+                        continue
+                    }
+
+                    candidates += block.world.getBlockAt(
                         block.location.clone().add(x.toDouble(), y.toDouble(), z.toDouble())
                     )
-
-                    if (toBreak.location.blockY !in block.world.minHeight..block.world.maxHeight) {
-                        continue
-                    }
-
-                    if (blacklist.matches(toBreak)) {
-                        continue
-                    }
-
-                    if (whitelist != null) {
-                        if (!whitelist.matches(toBreak)) {
-                            continue
-                        }
-                    }
-
-                    if (config.getBoolOrNull("check_hardness") != false) {
-                        if (Blocks.hardness(toBreak) < 0 || Blocks.hardness(toBreak) > Blocks.hardness(block)) {
-                            continue
-                        }
-                    }
-
-                    if (Blocks.hardness(toBreak) < 0) {
-                        continue
-                    }
-
-                    if (toBreak.type == Material.AIR) {
-                        continue
-                    }
-
-                    if (!AntigriefManager.canBreakBlock(player, toBreak)) {
-                        continue
-                    }
-
-                    blocks.add(toBreak)
                 }
             }
         }
 
-        player.breakBlocksSafely(blocks, preventTriggers)
+        return candidates
+    }
 
-        return true
+    /**
+     * Every block in [depth] flat layers of [radius], starting at the layer containing [block]
+     * and extending in the direction the player is mining. Excludes the block itself.
+     */
+    private fun layeredCandidates(
+        config: Config,
+        player: Player,
+        block: Block,
+        radius: Int,
+        depth: Int,
+        noCorners: Boolean
+    ): List<Block> {
+        val axes = resolveMiningAxes(config, player, block)
+        val candidates = mutableListOf<Block>()
+
+        for (layer in 0 until depth) {
+            for (up in (-radius..radius)) {
+                for (right in (-radius..radius)) {
+                    if (layer == 0 && up == 0 && right == 0) {
+                        continue
+                    }
+
+                    if (noCorners && abs(up) == radius && abs(right) == radius) {
+                        continue
+                    }
+
+                    candidates += block.world.getBlockAt(
+                        block.location.clone().add(
+                            axes.right.x * right + axes.up.x * up + axes.forward.x * layer,
+                            axes.right.y * right + axes.up.y * up + axes.forward.y * layer,
+                            axes.right.z * right + axes.up.z * up + axes.forward.z * layer
+                        )
+                    )
+                }
+            }
+        }
+
+        return candidates
+    }
+
+    private fun isCorner(radius: Int, x: Int, y: Int, z: Int): Boolean {
+        val atXCorner = abs(x) == radius
+        val atYCorner = abs(y) == radius
+        val atZCorner = abs(z) == radius
+
+        return atXCorner && atYCorner
+                || atXCorner && atZCorner
+                || atYCorner && atZCorner
     }
 }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadiusOneDeep.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadiusOneDeep.kt
@@ -4,7 +4,6 @@ import com.willfp.eco.core.blocks.Blocks
 import com.willfp.eco.core.blocks.matches
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.integrations.antigrief.AntigriefManager
-import com.willfp.eco.util.simplify
 import com.willfp.libreforge.ArgType
 import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.arguments
@@ -16,6 +15,7 @@ import org.bukkit.Material
 import org.bukkit.block.Block
 import kotlin.math.abs
 
+@Deprecated("Use mine_radius with depth: 1 instead")
 object EffectMineRadiusOneDeep : MineBlockEffect<NoCompileData>("mine_radius_one_deep") {
     override val description = "Mines blocks in a radius around the triggered block, only one layer deep in the direction the player is facing."
     override val categories = setOf("world")
@@ -68,6 +68,14 @@ object EffectMineRadiusOneDeep : MineBlockEffect<NoCompileData>("mine_radius_one
             type = ArgType.BOOLEAN,
             default = "true"
         )
+        optional(
+            "use_blockface",
+            description = "Whether to orient the layer by the face of the block the player is " +
+                    "looking at, rather than by their look direction. Falls back to the look " +
+                    "direction if the player isn't looking at the triggered block.",
+            type = ArgType.BOOLEAN,
+            default = "false"
+        )
     }
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
@@ -87,7 +95,7 @@ object EffectMineRadiusOneDeep : MineBlockEffect<NoCompileData>("mine_radius_one
 
         val blocks = mutableSetOf<Block>()
 
-        val ignoreVector = player.location.direction.simplify()
+        val ignoreVector = resolveForwardAxis(config, player, block)
 
         for (x in (-radius..radius)) {
             for (y in (-radius..radius)) {

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineShape.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineShape.kt
@@ -4,7 +4,6 @@ import com.willfp.eco.core.blocks.Blocks
 import com.willfp.eco.core.blocks.matches
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.integrations.antigrief.AntigriefManager
-import com.willfp.eco.util.simplify
 import com.willfp.libreforge.ArgType
 import com.willfp.libreforge.NoCompileData
 import com.willfp.libreforge.arguments
@@ -14,7 +13,6 @@ import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import org.bukkit.Material
 import org.bukkit.block.Block
-import org.bukkit.util.Vector
 
 object EffectMineShape : MineBlockEffect<NoCompileData>("mine_shape") {
     override val description = "Breaks blocks in a custom 2D grid shape relative to the block the player mines."
@@ -68,6 +66,14 @@ object EffectMineShape : MineBlockEffect<NoCompileData>("mine_shape") {
             type = ArgType.BOOLEAN,
             default = "true"
         )
+        optional(
+            "use_blockface",
+            description = "Whether to orient the shape by the face of the block the player is " +
+                    "looking at, rather than by their look direction. Falls back to the look " +
+                    "direction if the player isn't looking at the trigger block.",
+            type = ArgType.BOOLEAN,
+            default = "false"
+        )
     }
 
     override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
@@ -101,19 +107,10 @@ object EffectMineShape : MineBlockEffect<NoCompileData>("mine_shape") {
             return false
         }
 
-        val direction = player.location.direction
-        val forwardAxis = direction.clone().simplify()
-        val worldUp = Vector(0.0, 1.0, 0.0)
-
-        val upAxis: Vector
-        val rightAxis: Vector
-        if (forwardAxis.y != 0.0) {
-            upAxis = Vector(direction.x, 0.0, direction.z).simplify()
-            rightAxis = upAxis.clone().crossProduct(worldUp).simplify()
-        } else {
-            upAxis = worldUp.clone()
-            rightAxis = forwardAxis.clone().crossProduct(worldUp).simplify()
-        }
+        val axes = resolveMiningAxes(config, player, triggerBlock)
+        val forwardAxis = axes.forward
+        val upAxis = axes.up
+        val rightAxis = axes.right
 
         val preventTriggers = config.getBool("prevent_trigger")
         val whitelist = config.getStringsOrNull("whitelist")?.map { Blocks.lookup(it) }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/templates/MineBlockEffect.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/templates/MineBlockEffect.kt
@@ -2,16 +2,24 @@ package com.willfp.libreforge.effects.templates
 
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.util.runExempted
+import com.willfp.eco.util.simplify
 import com.willfp.libreforge.effects.Effect
 import com.willfp.libreforge.plugin
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.FluidCollisionMode
 import org.bukkit.Material
 import org.bukkit.block.Block
+import org.bukkit.block.BlockFace
 import org.bukkit.entity.Player
+import org.bukkit.util.Vector
 
 abstract class MineBlockEffect<T : Any>(id: String) : Effect<T>(id) {
     private val ignoreKey = "blockbreakevent-ignore"
+
+    // Slightly beyond the furthest a player can reach a block from, so that the block face
+    // raytrace can't miss but also doesn't scan needlessly far.
+    private val reachDistance = 7.0
 
     override val parameters = setOf(
         TriggerParameter.PLAYER
@@ -20,6 +28,59 @@ abstract class MineBlockEffect<T : Any>(id: String) : Effect<T>(id) {
     override fun shouldTrigger(config: Config, data: TriggerData, compileData: T): Boolean {
         val block = data.block ?: data.location?.block ?: return false
         return !block.hasMetadata(ignoreKey)
+    }
+
+    /**
+     * The axes used to orient a directional mining effect, in block space.
+     *
+     * [forward] points into the block the player is mining, [up] and [right] span the plane
+     * perpendicular to it. All three are unit vectors along a single axis.
+     */
+    protected class MiningAxes(
+        val forward: Vector,
+        val up: Vector,
+        val right: Vector
+    )
+
+    /**
+     * Get the axis pointing into [triggerBlock] for a [player].
+     *
+     * If the use_blockface argument is enabled, this is taken from the face of the block the
+     * player is looking at, otherwise it's taken from the player's look direction. The look
+     * direction is also used as a fallback if the player isn't looking at the trigger block,
+     * which happens when the effect is run from a trigger other than mine_block.
+     */
+    protected fun resolveForwardAxis(config: Config, player: Player, triggerBlock: Block): Vector {
+        if (config.getBool("use_blockface")) {
+            val ray = player.rayTraceBlocks(reachDistance, FluidCollisionMode.NEVER)
+            val face = ray?.hitBlockFace
+
+            if (ray?.hitBlock == triggerBlock && face != null && face != BlockFace.SELF) {
+                // The face points out of the block, towards the player, so it has to be flipped.
+                return face.direction.multiply(-1.0)
+            }
+        }
+
+        return player.location.direction.simplify()
+    }
+
+    /**
+     * Get the full set of [MiningAxes] for a [player] mining [triggerBlock].
+     */
+    protected fun resolveMiningAxes(config: Config, player: Player, triggerBlock: Block): MiningAxes {
+        val forward = resolveForwardAxis(config, player, triggerBlock)
+        val worldUp = Vector(0.0, 1.0, 0.0)
+
+        // When mining vertically there's no meaningful world up, so the player's horizontal
+        // look direction is used to orient the plane instead.
+        return if (forward.y != 0.0) {
+            val direction = player.location.direction
+            val up = Vector(direction.x, 0.0, direction.z).simplify()
+
+            MiningAxes(forward, up, up.clone().crossProduct(worldUp).simplify())
+        } else {
+            MiningAxes(forward, worldUp.clone(), forward.clone().crossProduct(worldUp).simplify())
+        }
     }
 
     protected fun Player.breakBlocksSafely(blocks: Collection<Block>, preventTriggers: Boolean = false) {


### PR DESCRIPTION
## Description

Added `BlockFace` controls to mining effects (`use_blockface` `true`/`false`).
Also added depth controls to `EffectMineRadius`, and deprecated `EffectMineRadiusOneDeep`.
For backwards compatibility I did add `BlockFace` controls to `EffectMineRadiusOneDeep`.

### QA

#### `BlockFace` with `mine_radius`
```yaml
effects:
  - id: mine_radius
    args:
      radius: 1
      depth: 1
      use_blockface: true
      prevent_trigger: true
    triggers:
      - mine_block
```

#### Look direction with `mine_radius` (default behaviour, matches `master` branch)
```yaml
effects:
  - id: mine_radius
    args:
      radius: 1
      depth: 1
      use_blockface: false
      prevent_trigger: true
    triggers:
      - mine_block
```

#### `mine_radius` with `BlockFace` and `depth` controls.
```yaml
effects:
  - id: mine_radius
    args:
      radius: 1
      depth: 3
      use_blockface: true
      prevent_trigger: true
    triggers:
      - mine_block
```

#### `mine_radius` with `no_corners` and `radius`
```yaml
effects:
  - id: mine_radius
    args:
      radius: 2
      no_corners: true
      prevent_trigger: true
    triggers:
      - mine_block
```

#### `mine_shape` with `BlockFace`
```yaml
effects:
  - id: mine_shape
    args:
      shape:
        - "--X--"
        - "--X--"
        - "XXTXX"
        - "--X--"
        - "--X--"
      depth: 1
      use_blockface: true
      prevent_trigger: true
    triggers:
      - mine_block
```

#### `drill` with `BlockFace`
```yaml
effects:
  - id: drill
    args:
      amount: 4
      check_hardness: false
      use_blockface: true
      prevent_trigger: true
    triggers:
      - mine_block
```

#### Deprecated `mine_radius_one_deep` with `BlockFace`
```yaml
effects:
  - id: mine_radius_one_deep
    args:
      radius: 1
      use_blockface: true
      prevent_trigger: true
    triggers:
      - mine_block
```