### PR TITLE
feat: add keep_events option to prevent_trigger [EcoHub-10]

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectBreakBlock.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectBreakBlock.kt
@@ -19,9 +19,12 @@ object EffectBreakBlock : MineBlockEffect<NoCompileData>("break_block") {
     override val arguments = arguments {
         optional(
             "prevent_trigger",
-            description = "If true, breaking this block will not fire further libreforge triggers.",
-            type = ArgType.BOOLEAN,
-            default = "false"
+            description = "Whether the broken block should fire further libreforge triggers. " +
+                    "true breaks it silently, firing no events at all; keep_events breaks it normally, " +
+                    "so drops and block events still happen, but stops the mine_block trigger from running again.",
+            type = ArgType.STRING,
+            default = "false",
+            choices = listOf("false", "true", "keep_events")
         )
     }
 
@@ -30,7 +33,7 @@ object EffectBreakBlock : MineBlockEffect<NoCompileData>("break_block") {
 
         val player = data.player ?: return false
 
-        val preventTriggers = config.getBool("prevent_trigger")
+        val preventTriggers = preventTriggerMode(config)
 
         player.breakBlocksSafely(listOf(block), preventTriggers)
 

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDrill.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectDrill.kt
@@ -44,9 +44,12 @@ object EffectDrill : MineBlockEffect<NoCompileData>("drill") {
         )
         optional(
             "prevent_trigger",
-            description = "If true, breaking additional blocks will not fire further libreforge triggers.",
-            type = ArgType.BOOLEAN,
-            default = "false"
+            description = "Whether the additional blocks should fire further libreforge triggers. " +
+                    "true breaks them silently, firing no events at all; keep_events breaks them normally, " +
+                    "so drops and block events still happen, but stops the mine_block trigger from running again.",
+            type = ArgType.STRING,
+            default = "false",
+            choices = listOf("false", "true", "keep_events")
         )
         optional(
             "whitelist",
@@ -82,7 +85,7 @@ object EffectDrill : MineBlockEffect<NoCompileData>("drill") {
         val whitelist = config.getStringsOrNull("whitelist")?.map { Blocks.lookup(it) }
         val blacklist = config.getStrings("blacklisted_blocks").map { Blocks.lookup(it) }
 
-        val preventTriggers = config.getBool("prevent_trigger")
+        val preventTriggers = preventTriggerMode(config)
 
         val blocks = mutableSetOf<Block>()
 

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadius.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadius.kt
@@ -43,9 +43,12 @@ object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
         )
         optional(
             "prevent_trigger",
-            description = "Whether breaking these blocks should prevent triggering further effects.",
-            type = ArgType.BOOLEAN,
-            default = "false"
+            description = "Whether the broken blocks should fire further libreforge triggers. " +
+                    "true breaks them silently, firing no events at all; keep_events breaks them normally, " +
+                    "so drops and block events still happen, but stops the mine_block trigger from running again.",
+            type = ArgType.STRING,
+            default = "false",
+            choices = listOf("false", "true", "keep_events")
         )
         optional(
             "disable_on_sneak",
@@ -94,7 +97,7 @@ object EffectMineRadius : MineBlockEffect<NoCompileData>("mine_radius") {
 
         val radius = config.getIntFromExpression("radius", data)
 
-        val preventTriggers = config.getBool("prevent_trigger")
+        val preventTriggers = preventTriggerMode(config)
 
         if (player.isSneaking && config.getBool("disable_on_sneak")) {
             return false

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadiusOneDeep.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineRadiusOneDeep.kt
@@ -34,9 +34,12 @@ object EffectMineRadiusOneDeep : MineBlockEffect<NoCompileData>("mine_radius_one
         )
         optional(
             "prevent_trigger",
-            description = "Whether breaking these blocks should prevent triggering further effects.",
-            type = ArgType.BOOLEAN,
-            default = "false"
+            description = "Whether the broken blocks should fire further libreforge triggers. " +
+                    "true breaks them silently, firing no events at all; keep_events breaks them normally, " +
+                    "so drops and block events still happen, but stops the mine_block trigger from running again.",
+            type = ArgType.STRING,
+            default = "false",
+            choices = listOf("false", "true", "keep_events")
         )
         optional(
             "disable_on_sneak",
@@ -84,7 +87,7 @@ object EffectMineRadiusOneDeep : MineBlockEffect<NoCompileData>("mine_radius_one
 
         val radius = config.getIntFromExpression("radius", data)
 
-        val preventTriggers = config.getBool("prevent_trigger")
+        val preventTriggers = preventTriggerMode(config)
 
         if (player.isSneaking && config.getBool("disable_on_sneak")) {
             return false

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineShape.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineShape.kt
@@ -50,9 +50,12 @@ object EffectMineShape : MineBlockEffect<NoCompileData>("mine_shape") {
         )
         optional(
             "prevent_trigger",
-            description = "Whether to prevent the broken blocks from re-triggering this effect.",
-            type = ArgType.BOOLEAN,
-            default = "false"
+            description = "Whether the broken blocks should fire further libreforge triggers. " +
+                    "true breaks them silently, firing no events at all; keep_events breaks them normally, " +
+                    "so drops and block events still happen, but stops the mine_block trigger from running again.",
+            type = ArgType.STRING,
+            default = "false",
+            choices = listOf("false", "true", "keep_events")
         )
         optional(
             "disable_on_sneak",
@@ -112,7 +115,7 @@ object EffectMineShape : MineBlockEffect<NoCompileData>("mine_shape") {
         val upAxis = axes.up
         val rightAxis = axes.right
 
-        val preventTriggers = config.getBool("prevent_trigger")
+        val preventTriggers = preventTriggerMode(config)
         val whitelist = config.getStringsOrNull("whitelist")?.map { Blocks.lookup(it) }
         val blacklist = config.getStrings("blacklisted_blocks").map { Blocks.lookup(it) }
 

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineVein.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/impl/EffectMineVein.kt
@@ -39,9 +39,12 @@ object EffectMineVein : MineBlockEffect<FilterList>("mine_vein") {
         )
         optional(
             "prevent_trigger",
-            description = "Whether to prevent the vein blocks from re-triggering this effect.",
-            type = ArgType.BOOLEAN,
-            default = "false"
+            description = "Whether the vein blocks should fire further libreforge triggers. " +
+                    "true breaks them silently, firing no events at all; keep_events breaks them normally, " +
+                    "so drops and block events still happen, but stops the mine_block trigger from running again.",
+            type = ArgType.STRING,
+            default = "false",
+            choices = listOf("false", "true", "keep_events")
         )
         optional(
             "disable_on_sneak",
@@ -57,7 +60,7 @@ object EffectMineVein : MineBlockEffect<FilterList>("mine_vein") {
 
         val limit = config.getIntFromExpression("limit", data)
 
-        val preventTriggers = config.getBool("prevent_trigger")
+        val preventTriggers = preventTriggerMode(config)
 
         if (player.isSneaking && config.getBool("disable_on_sneak")) {
             return false

--- a/core/common/src/main/kotlin/com/willfp/libreforge/effects/templates/MineBlockEffect.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/effects/templates/MineBlockEffect.kt
@@ -14,9 +14,33 @@ import org.bukkit.block.BlockFace
 import org.bukkit.entity.Player
 import org.bukkit.util.Vector
 
-abstract class MineBlockEffect<T : Any>(id: String) : Effect<T>(id) {
-    private val ignoreKey = "blockbreakevent-ignore"
+/**
+ * How the extra blocks broken by a mine effect interact with triggers.
+ */
+enum class PreventTriggerMode {
+    /**
+     * Break the blocks as the player, firing all events and triggers.
+     *
+     * Other mine effects are still stopped from re-triggering, to prevent infinite recursion.
+     */
+    NONE,
 
+    /**
+     * Break the blocks without firing any events at all.
+     */
+    ALL,
+
+    /**
+     * Break the blocks as the player, firing all events, but stop the mine_block trigger from
+     * dispatching for them.
+     *
+     * Drops, block break events, and the triggers derived from them (eg block_item_drop) still
+     * fire, so block regeneration plugins and effect chains bound to those triggers keep working.
+     */
+    KEEP_EVENTS
+}
+
+abstract class MineBlockEffect<T : Any>(id: String) : Effect<T>(id) {
     // Slightly beyond the furthest a player can reach a block from, so that the block face
     // raytrace can't miss but also doesn't scan needlessly far.
     private val reachDistance = 7.0
@@ -83,23 +107,62 @@ abstract class MineBlockEffect<T : Any>(id: String) : Effect<T>(id) {
         }
     }
 
-    protected fun Player.breakBlocksSafely(blocks: Collection<Block>, preventTriggers: Boolean = false) {
+    protected fun Player.breakBlocksSafely(blocks: Collection<Block>, mode: PreventTriggerMode) {
         if (plugin.configYml.getBool("effects.use-setblock-break")) {
             blocks.forEach { it.type = Material.AIR }
-        } else if (preventTriggers) {
-            blocks.forEach { it.breakNaturally() }
-        } else {
-            this.runExempted {
-                for (block in blocks) {
-                    if (block.world != this.world) {
-                        continue
-                    }
+            return
+        }
 
-                    block.setMetadata(ignoreKey, plugin.createMetadataValue(true))
-                    this.breakBlock(block)
-                    block.removeMetadata(ignoreKey, plugin)
+        if (mode == PreventTriggerMode.ALL) {
+            blocks.forEach { it.breakNaturally() }
+            return
+        }
+
+        this.runExempted {
+            for (block in blocks) {
+                if (block.world != this.world) {
+                    continue
                 }
+
+                block.setMetadata(ignoreKey, plugin.createMetadataValue(true))
+
+                if (mode == PreventTriggerMode.KEEP_EVENTS) {
+                    block.setMetadata(preventTriggerKey, plugin.createMetadataValue(true))
+                }
+
+                this.breakBlock(block)
+
+                block.removeMetadata(ignoreKey, plugin)
+                block.removeMetadata(preventTriggerKey, plugin)
             }
+        }
+    }
+
+    @Deprecated("Use the PreventTriggerMode overload instead.")
+    protected fun Player.breakBlocksSafely(blocks: Collection<Block>, preventTriggers: Boolean = false) =
+        breakBlocksSafely(
+            blocks,
+            if (preventTriggers) PreventTriggerMode.ALL else PreventTriggerMode.NONE
+        )
+
+    companion object {
+        internal const val ignoreKey = "blockbreakevent-ignore"
+        internal const val preventTriggerKey = "blockbreakevent-prevent-trigger"
+
+        /**
+         * Read the prevent_trigger mode from a [config].
+         *
+         * Anything other than the literal string keep_events is read with getBool, exactly as
+         * before, so existing configs keep the behaviour they already had.
+         */
+        @JvmStatic
+        fun preventTriggerMode(config: Config) = when {
+            config.get("prevent_trigger")?.toString()?.lowercase() == "keep_events" ->
+                PreventTriggerMode.KEEP_EVENTS
+
+            config.getBool("prevent_trigger") -> PreventTriggerMode.ALL
+
+            else -> PreventTriggerMode.NONE
         }
     }
 }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMineBlock.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/triggers/impl/TriggerMineBlock.kt
@@ -1,6 +1,7 @@
 package com.willfp.libreforge.triggers.impl
 
 import com.willfp.eco.core.integrations.antigrief.AntigriefManager
+import com.willfp.libreforge.effects.templates.MineBlockEffect
 import com.willfp.libreforge.toDispatcher
 import com.willfp.libreforge.triggers.Trigger
 import com.willfp.libreforge.triggers.TriggerData
@@ -34,6 +35,12 @@ object TriggerMineBlock : Trigger("mine_block") {
         val block = event.block
 
         if (!AntigriefManager.canBreakBlock(player, block)) {
+            return
+        }
+
+        // Broken by a mine effect with prevent_trigger: keep_events, so the events fire as normal
+        // but the block shouldn't re-run the effect chain that broke it.
+        if (block.hasMetadata(MineBlockEffect.preventTriggerKey)) {
             return
         }
 


### PR DESCRIPTION
## Description

Upgraded '`prevent_trigger`' from a Boolean to a String.

### Before

```
  ┌─────────────────┬─────────────────────┬────────┬────────────┐
  │      Value      │    Break method     │ Events │ mine_block │
  ├─────────────────┼─────────────────────┼────────┼────────────┤
  │ false (default) │ player.breakBlock() │ yes    │ fires      │
  ├─────────────────┼─────────────────────┼────────┼────────────┤
  │ true            │ breakNaturally()    │ none   │ none       │
  └─────────────────┴─────────────────────┴────────┴────────────┘
```

### Now
```
  ┌─────────────────┬─────────────────────┬────────┬────────────┐
  │      Value      │    Break method     │ Events │ mine_block │
  ├─────────────────┼─────────────────────┼────────┼────────────┤
  │ false (default) │ player.breakBlock() │ yes    │ fires      │
  ├─────────────────┼─────────────────────┼────────┼────────────┤
  │ true            │ breakNaturally()    │ none   │ none       │
  ├─────────────────┼─────────────────────┼────────┼────────────┤
  │ keep_events     │ player.breakBlock() │ yes    │ suppressed │
  └─────────────────┴─────────────────────┴────────┴────────────┘
  ```

### QA

#### `mine_radius` with `prevent_trigger` `false` (legacy regression check)
```yaml
effects:
  - id: mine_radius
    args:
      radius: 1
      depth: 1
      prevent_trigger: false
    triggers:
      - mine_block
```

#### `mine_radius` with `prevent_trigger` `true`
```yaml
effects:
  - id: mine_radius
    args:
      radius: 1
      depth: 1
      prevent_trigger: true
    triggers:
      - mine_block
```

#### `mine_radius` with `prevent_trigger` `keep_events`
```yaml
effects:
  - id: mine_radius
    args:
      radius: 1
      depth: 1
      prevent_trigger: keep_events
    triggers:
      - mine_block
```

#### `mine_vein` with `prevent_trigger` `keep_events`
```yaml
effects:
  - id: mine_vein
    args:
      limit: 20
      prevent_trigger: keep_events
    triggers:
      - mine_block
```

#### `keep_events` on `break_block`, fired from a non-mining `trigger` (`click_block`).
```yaml
effects:
  - id: break_block
    args:
      prevent_trigger: keep_events
    triggers:
      - click_block
```