### PR TITLE
fix: effect responsiveness when swapping armor via hotbar [EcoHub-15]

### DIFF
--- a/core/common/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/HolderUpdates.kt
@@ -88,6 +88,12 @@ object ItemRefreshListener : Listener {
 
         inventoryClickTimeouts.put(player.uniqueId, Unit)
 
-        player.toDispatcher().refreshHolders()
+        val dispatcher = player.toDispatcher()
+
+        // The click hasn't been applied to the inventory yet, so refreshing now would cache
+        // the holders from before the click for as long as the holder cache lives.
+        plugin.scheduler.run {
+            dispatcher.refreshHolders()
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixed armor swapping mechanism.

### QA
```
  ┌───────────────────────────────┬────────────────────────────────────────┬──────────────────────────┐
  │             File              │               Condition                │  Potion (visual proof)   │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_helmet_diamond.yml       │ wearing_helmet: diamond_helmet         │ GLOWING                  │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_helmet_iron.yml          │ wearing_helmet: iron_helmet            │ NIGHT_VISION             │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_chestplate.yml           │ wearing_chestplate: diamond_chestplate │ SPEED III                │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_leggings.yml             │ wearing_leggings: diamond_leggings     │ SATURATION               │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_boots.yml                │ wearing_boots: diamond_boots           │ WATER_BREATHING          │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_mainhand.yml             │ in_mainhand: diamond_sword             │ GLOWING                  │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_offhand.yml              │ in_offhand: shield                     │ NIGHT_VISION             │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_change_armor_trigger.yml │ none (always active)                   │ — (reports change_armor) │
  └───────────────────────────────┴────────────────────────────────────────┴──────────────────────────┘
  ```