### PR TITLE
feat: add CMI effects system integration [EcoHub-131]

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -18,6 +18,12 @@ dependencies {
     compileOnly("com.github.Zrips:Jobs:v5.2.6.3") {
         exclude(group = "com.bgsoftware", module = "WildStackerAPI")
     }
+    compileOnly("com.github.Zrips:CMI-API:9.8.6.4") {
+        exclude("*", "*")
+    }
+    compileOnly("com.github.Zrips:CMILib:1.5.8.1") {
+        exclude("*", "*")
+    }
     compileOnly("com.github.MilkBowl:VaultAPI:1.7") {
         exclude("*", "*")
     }

--- a/core/common/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/LibreforgeSpigotPlugin.kt
@@ -30,6 +30,7 @@ import com.willfp.libreforge.integrations.axplugins.axenvoy.AxEnvoyIntegration
 import com.willfp.libreforge.integrations.axplugins.axtrade.AxTradeIntegration
 import com.willfp.libreforge.integrations.bettermodel.BetterModelIntegration
 import com.willfp.libreforge.integrations.citizens.CitizensIntegration
+import com.willfp.libreforge.integrations.cmi.CMIIntegration
 import com.willfp.libreforge.integrations.custom_blocks.craftengine.CraftEngineIntegration
 import com.willfp.libreforge.integrations.custom_blocks.itemsadder.ItemsAdderIntegration
 import com.willfp.libreforge.integrations.custom_blocks.nexo.NexoIntegration
@@ -244,6 +245,7 @@ class LibreforgeSpigotPlugin : EcoPlugin() {
         return listOf(
             IntegrationLoader("AuraSkills") { AuraSkillsIntegration.load(this) },
             IntegrationLoader("Jobs") { JobsIntegration.load(this) },
+            IntegrationLoader("CMI") { CMIIntegration.load(this) },
             IntegrationLoader("LevelledMobs") { LevelledMobsIntegration.load(this) },
             IntegrationLoader("RoseStacker") { RoseStackerIntegration.load(this) },
             IntegrationLoader("mcMMO") { McMMOIntegration.load(this) },

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/CMIIntegration.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/CMIIntegration.kt
@@ -1,0 +1,102 @@
+package com.willfp.libreforge.integrations.cmi
+
+import com.willfp.eco.core.EcoPlugin
+import com.willfp.libreforge.conditions.Conditions
+import com.willfp.libreforge.effects.Effects
+import com.willfp.libreforge.filters.Filters
+import com.willfp.libreforge.integrations.LoadableIntegration
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiBalanceAbove
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiHasRank
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiIsAfk
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiIsGod
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiIsJailed
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiIsMuted
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiIsVanished
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiKitAvailable
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiPlaytimeAbove
+import com.willfp.libreforge.integrations.cmi.impl.ConditionCmiStatisticAbove
+import com.willfp.libreforge.integrations.cmi.impl.EffectCmiGiveBalance
+import com.willfp.libreforge.integrations.cmi.impl.EffectCmiGiveKit
+import com.willfp.libreforge.integrations.cmi.impl.EffectCmiSetBalance
+import com.willfp.libreforge.integrations.cmi.impl.EffectCmiTakeBalance
+import com.willfp.libreforge.integrations.cmi.impl.EffectCmiTeleportToWarp
+import com.willfp.libreforge.integrations.cmi.impl.FilterCmiKit
+import com.willfp.libreforge.integrations.cmi.impl.FilterCmiPortal
+import com.willfp.libreforge.integrations.cmi.impl.FilterCmiSellType
+import com.willfp.libreforge.integrations.cmi.impl.FilterCmiWarp
+import com.willfp.libreforge.integrations.cmi.impl.MutatorCmiLocationToHome
+import com.willfp.libreforge.integrations.cmi.impl.MutatorCmiLocationToWarp
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiAfkEnter
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiAfkLeave
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiBalanceChange
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiChequeCreate
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiChequeUse
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiHomeCreate
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiHomeRemove
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiJail
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiKitAcquire
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiNicknameChange
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiPortalUse
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiSellItems
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiSit
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiTeleportRequest
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiUnjail
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiUnvanish
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiVanish
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiWarn
+import com.willfp.libreforge.integrations.cmi.impl.TriggerCmiWarpUse
+import com.willfp.libreforge.mutators.Mutators
+import com.willfp.libreforge.triggers.Triggers
+
+object CMIIntegration : LoadableIntegration {
+    override fun load(plugin: EcoPlugin) {
+        Triggers.register(TriggerCmiBalanceChange)
+        Triggers.register(TriggerCmiChequeCreate)
+        Triggers.register(TriggerCmiChequeUse)
+        Triggers.register(TriggerCmiSellItems)
+        Triggers.register(TriggerCmiAfkEnter)
+        Triggers.register(TriggerCmiAfkLeave)
+        Triggers.register(TriggerCmiVanish)
+        Triggers.register(TriggerCmiUnvanish)
+        Triggers.register(TriggerCmiJail)
+        Triggers.register(TriggerCmiUnjail)
+        Triggers.register(TriggerCmiNicknameChange)
+        Triggers.register(TriggerCmiWarn)
+        Triggers.register(TriggerCmiSit)
+        Triggers.register(TriggerCmiHomeCreate)
+        Triggers.register(TriggerCmiHomeRemove)
+        Triggers.register(TriggerCmiWarpUse)
+        Triggers.register(TriggerCmiPortalUse)
+        Triggers.register(TriggerCmiTeleportRequest)
+        Triggers.register(TriggerCmiKitAcquire)
+
+        Conditions.register(ConditionCmiIsAfk)
+        Conditions.register(ConditionCmiIsVanished)
+        Conditions.register(ConditionCmiIsJailed)
+        Conditions.register(ConditionCmiIsMuted)
+        Conditions.register(ConditionCmiIsGod)
+        Conditions.register(ConditionCmiHasRank)
+        Conditions.register(ConditionCmiPlaytimeAbove)
+        Conditions.register(ConditionCmiBalanceAbove)
+        Conditions.register(ConditionCmiKitAvailable)
+        Conditions.register(ConditionCmiStatisticAbove)
+
+        Effects.register(EffectCmiGiveBalance)
+        Effects.register(EffectCmiTakeBalance)
+        Effects.register(EffectCmiSetBalance)
+        Effects.register(EffectCmiGiveKit)
+        Effects.register(EffectCmiTeleportToWarp)
+
+        Filters.register(FilterCmiWarp)
+        Filters.register(FilterCmiPortal)
+        Filters.register(FilterCmiKit)
+        Filters.register(FilterCmiSellType)
+
+        Mutators.register(MutatorCmiLocationToWarp)
+        Mutators.register(MutatorCmiLocationToHome)
+    }
+
+    override fun getPluginName(): String {
+        return "CMI"
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiBalanceAbove.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiBalanceAbove.kt
@@ -1,0 +1,60 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.Zrips.CMI.events.CMIUserBalanceChangeEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.updateEffects
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+
+object ConditionCmiBalanceAbove : Condition<NoCompileData>("cmi_balance_above") {
+    override val description = "Passes when the player's CMI balance is above a specified amount."
+    override val categories = setOf("economy", "player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val arguments = arguments {
+        require(
+            "amount",
+            "You must specify the amount of money!",
+            description = "The amount of money the player's balance must exceed. Supports expressions.",
+            type = ArgType.EXPRESSION
+        )
+        optional(
+            "world",
+            description = "The world to read the balance from, for per-world economies. " +
+                    "Defaults to the player's global balance.",
+            type = ArgType.STRING
+        )
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun handle(event: CMIUserBalanceChangeEvent) {
+        event.user?.player?.toDispatcher()?.updateEffects()
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        val world = config.getStringOrNull("world")
+        val balance = (if (world.isNullOrEmpty()) user.balance else user.getBalance(world)) ?: return false
+
+        return balance > config.getDoubleFromExpression("amount", player)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiHasRank.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiHasRank.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.util.containsIgnoreCase
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+
+object ConditionCmiHasRank : Condition<NoCompileData>("cmi_has_rank") {
+    override val description = "Passes when the player has one of the specified CMI ranks."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val arguments = arguments {
+        require(
+            "rank",
+            "You must specify the rank names!",
+            description = "The CMI rank name(s) to check against. Matched case-insensitively.",
+            type = ArgType.STRING_LIST
+        )
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+        val rank = user.rank?.name ?: return false
+
+        return config.getStrings("rank").containsIgnoreCase(rank)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsAfk.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsAfk.kt
@@ -1,0 +1,46 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.Zrips.CMI.events.CMIAfkEnterEvent
+import com.Zrips.CMI.events.CMIAfkLeaveEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.updateEffects
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+
+object ConditionCmiIsAfk : Condition<NoCompileData>("cmi_is_afk") {
+    override val description = "Passes when the player is AFK."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun handleEnter(event: CMIAfkEnterEvent) {
+        event.player?.toDispatcher()?.updateEffects()
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun handleLeave(event: CMIAfkLeaveEvent) {
+        event.player?.toDispatcher()?.updateEffects()
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        return user.isAfk
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsGod.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsGod.kt
@@ -1,0 +1,30 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+
+object ConditionCmiIsGod : Condition<NoCompileData>("cmi_is_god") {
+    override val description = "Passes when the player has CMI god mode enabled."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        return user.isGod
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsJailed.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsJailed.kt
@@ -1,0 +1,46 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.Zrips.CMI.events.CMIPlayerJailEvent
+import com.Zrips.CMI.events.CMIPlayerUnjailEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.updateEffects
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+
+object ConditionCmiIsJailed : Condition<NoCompileData>("cmi_is_jailed") {
+    override val description = "Passes when the player is in jail."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun handleJail(event: CMIPlayerJailEvent) {
+        event.user?.player?.toDispatcher()?.updateEffects()
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun handleUnjail(event: CMIPlayerUnjailEvent) {
+        event.user?.player?.toDispatcher()?.updateEffects()
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        return user.isJailed
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsMuted.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsMuted.kt
@@ -1,0 +1,30 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+
+object ConditionCmiIsMuted : Condition<NoCompileData>("cmi_is_muted") {
+    override val description = "Passes when the player is muted."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        return user.isMuted
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsVanished.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiIsVanished.kt
@@ -1,0 +1,46 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.Zrips.CMI.events.CMIPlayerUnVanishEvent
+import com.Zrips.CMI.events.CMIPlayerVanishEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.updateEffects
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+
+object ConditionCmiIsVanished : Condition<NoCompileData>("cmi_is_vanished") {
+    override val description = "Passes when the player is vanished."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun handleVanish(event: CMIPlayerVanishEvent) {
+        event.player?.toDispatcher()?.updateEffects()
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun handleUnVanish(event: CMIPlayerUnVanishEvent) {
+        event.player?.toDispatcher()?.updateEffects()
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        return user.isVanished
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiKitAvailable.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiKitAvailable.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+
+object ConditionCmiKitAvailable : Condition<NoCompileData>("cmi_kit_available") {
+    override val description = "Passes when the player is able to claim a specified kit."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "Does not pass if no kit with the given name exists."
+    )
+
+    override val arguments = arguments {
+        require(
+            "kit",
+            "You must specify the kit name!",
+            description = "The name of the CMI kit to check.",
+            type = ArgType.STRING
+        )
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+        val kit = CMI.getInstance()?.kitsManager?.getKit(config.getString("kit")) ?: return false
+
+        return user.canUseKit(kit)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiPlaytimeAbove.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiPlaytimeAbove.kt
@@ -1,0 +1,42 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+
+object ConditionCmiPlaytimeAbove : Condition<NoCompileData>("cmi_playtime_above") {
+    override val description = "Passes when the player has played for more than a specified number of hours."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "CMI tracks playtime in milliseconds; it is converted to hours before comparing."
+    )
+
+    override val arguments = arguments {
+        require(
+            "hours",
+            "You must specify the number of hours!",
+            description = "The number of hours of playtime the player must exceed. Supports expressions.",
+            type = ArgType.EXPRESSION
+        )
+    }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        return user.totalPlayTime / 3_600_000.0 > config.getDoubleFromExpression("hours", player)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiStatisticAbove.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/ConditionCmiStatisticAbove.kt
@@ -1,0 +1,59 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.Zrips.CMI.Modules.Statistics.StatsManager.CMIStatistic
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.Dispatcher
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.ProvidedHolder
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.conditions.Condition
+import com.willfp.libreforge.get
+import org.bukkit.entity.Player
+
+object ConditionCmiStatisticAbove : Condition<NoCompileData>("cmi_statistic_above") {
+    override val description = "Passes when a CMI statistic of the player is above a specified amount."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val arguments = arguments {
+        require(
+            "statistic",
+            "You must specify a valid CMI statistic!",
+            Config::getString
+        ) { name ->
+            lookup(name) != null
+        }
+        describe(
+            "statistic",
+            description = "The CMI statistic to read.",
+            type = ArgType.STRING,
+            enumClass = CMIStatistic::class
+        )
+        require(
+            "amount",
+            "You must specify the amount!",
+            description = "The value the statistic must exceed. Supports expressions.",
+            type = ArgType.EXPRESSION
+        )
+    }
+
+    private fun lookup(name: String?): CMIStatistic? =
+        CMIStatistic.values().firstOrNull { it.name.equals(name, ignoreCase = true) }
+
+    override fun isMet(
+        dispatcher: Dispatcher<*>,
+        config: Config,
+        holder: ProvidedHolder,
+        compileData: NoCompileData
+    ): Boolean {
+        val player = dispatcher.get<Player>() ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+        val statistic = lookup(config.getString("statistic")) ?: return false
+
+        return user.getStatistic(statistic) > config.getDoubleFromExpression("amount", player)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiGiveBalance.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiGiveBalance.kt
@@ -1,0 +1,41 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectCmiGiveBalance : Effect<NoCompileData>("cmi_give_balance") {
+    override val description = "Adds money to the player's CMI balance."
+    override val categories = setOf("economy")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require(
+            "amount",
+            "You must specify the amount of money to give!",
+            description = "The amount of money to add to the player's balance. Supports expressions.",
+            type = ArgType.EXPRESSION
+        )
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        user.deposit(config.getDoubleFromExpression("amount", data))
+
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiGiveKit.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiGiveKit.kt
@@ -1,0 +1,49 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getOrElse
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectCmiGiveKit : Effect<NoCompileData>("cmi_give_kit") {
+    override val description = "Gives the player a CMI kit."
+    override val categories = setOf("player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "Does nothing if no kit with the given name exists."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require(
+            "kit",
+            "You must specify the kit name!",
+            description = "The name of the CMI kit to give.",
+            type = ArgType.STRING
+        )
+        optional(
+            "give_items",
+            description = "Whether to give the kit's items as well as running its commands. Defaults to true.",
+            type = ArgType.BOOLEAN,
+            default = "true"
+        )
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val kitsManager = CMI.getInstance()?.kitsManager ?: return false
+        val kit = kitsManager.getKit(config.getString("kit")) ?: return false
+
+        kitsManager.giveKit(player, kit, config.getOrElse("give_items", true) { getBool(it) })
+
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiSetBalance.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiSetBalance.kt
@@ -1,0 +1,49 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import kotlin.math.absoluteValue
+
+object EffectCmiSetBalance : Effect<NoCompileData>("cmi_set_balance") {
+    override val description = "Sets the player's CMI balance to a specified amount."
+    override val categories = setOf("economy")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require(
+            "amount",
+            "You must specify the amount of money!",
+            description = "The amount to set the player's balance to. Supports expressions.",
+            type = ArgType.EXPRESSION
+        )
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+        val balance = user.balance ?: return false
+
+        val delta = config.getDoubleFromExpression("amount", data) - balance
+
+        if (delta > 0) {
+            user.deposit(delta)
+        } else if (delta < 0) {
+            user.withdraw(delta.absoluteValue)
+        }
+
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiTakeBalance.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiTakeBalance.kt
@@ -1,0 +1,55 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.getDoubleFromExpression
+import com.willfp.libreforge.getOrElse
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectCmiTakeBalance : Effect<NoCompileData>("cmi_take_balance") {
+    override val description = "Removes money from the player's CMI balance."
+    override val categories = setOf("economy")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require(
+            "amount",
+            "You must specify the amount of money to take!",
+            description = "The amount of money to remove from the player's balance. Supports expressions.",
+            type = ArgType.EXPRESSION
+        )
+        optional(
+            "require_balance",
+            description = "Whether the player must be able to afford the full amount. Defaults to true.",
+            type = ArgType.BOOLEAN,
+            default = "true"
+        )
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return false
+
+        val amount = config.getDoubleFromExpression("amount", data)
+        val requireBalance = config.getOrElse("require_balance", true) { getBool(it) }
+
+        if (requireBalance && !user.has(amount)) {
+            return false
+        }
+
+        user.withdraw(amount)
+
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiTeleportToWarp.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/EffectCmiTeleportToWarp.kt
@@ -1,0 +1,45 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object EffectCmiTeleportToWarp : Effect<NoCompileData>("cmi_teleport_to_warp") {
+    override val description = "Teleports the player to a CMI warp."
+    override val categories = setOf("movement")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "Does nothing if no warp with the given name exists."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override val arguments = arguments {
+        require(
+            "warp",
+            "You must specify the warp name!",
+            description = "The name of the CMI warp to teleport to.",
+            type = ArgType.STRING
+        )
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val location = CMI.getInstance()?.warpManager
+            ?.getWarp(config.getString("warp"))
+            ?.loc
+            ?.bukkitLoc
+            ?: return false
+
+        player.teleport(location)
+
+        return true
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiKit.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiKit.kt
@@ -1,0 +1,29 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIUserKitAcquireEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.util.containsIgnoreCase
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+
+object FilterCmiKit : Filter<NoCompileData, List<String>>("cmi_kit") {
+    override val description = "Matches when the player claimed one of the given CMI kits."
+    override val categories = setOf("player")
+    override val valueType = ArgType.STRING_LIST
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "Passes automatically when the event is not a CMI kit event."
+    )
+
+    override fun getValue(config: Config, data: TriggerData?, key: String): List<String> {
+        return config.getStrings(key)
+    }
+
+    override fun isMet(data: TriggerData, value: List<String>, compileData: NoCompileData): Boolean {
+        val event = data.event as? CMIUserKitAcquireEvent ?: return true
+
+        return value.containsIgnoreCase(event.kit?.configName ?: return false)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiPortal.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiPortal.kt
@@ -1,0 +1,29 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPortalUseEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.util.containsIgnoreCase
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+
+object FilterCmiPortal : Filter<NoCompileData, List<String>>("cmi_portal") {
+    override val description = "Matches when the player used one of the given CMI portals."
+    override val categories = setOf("player", "world")
+    override val valueType = ArgType.STRING_LIST
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "Passes automatically when the event is not a CMI portal event."
+    )
+
+    override fun getValue(config: Config, data: TriggerData?, key: String): List<String> {
+        return config.getStrings(key)
+    }
+
+    override fun isMet(data: TriggerData, value: List<String>, compileData: NoCompileData): Boolean {
+        val event = data.event as? CMIPortalUseEvent ?: return true
+
+        return value.containsIgnoreCase(event.portal?.name ?: return false)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiSellType.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiSellType.kt
@@ -1,0 +1,29 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerItemsSellEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.util.containsIgnoreCase
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+
+object FilterCmiSellType : Filter<NoCompileData, List<String>>("cmi_sell_type") {
+    override val description = "Matches when the items were sold through one of the given CMI sell types."
+    override val categories = setOf("economy", "player")
+    override val valueType = ArgType.STRING_LIST
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "Passes automatically when the event is not a CMI item sell event."
+    )
+
+    override fun getValue(config: Config, data: TriggerData?, key: String): List<String> {
+        return config.getStrings(key)
+    }
+
+    override fun isMet(data: TriggerData, value: List<String>, compileData: NoCompileData): Boolean {
+        val event = data.event as? CMIPlayerItemsSellEvent ?: return true
+
+        return value.containsIgnoreCase(event.sellType?.name ?: return false)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiWarp.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/FilterCmiWarp.kt
@@ -1,0 +1,29 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerWarpEvent
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.util.containsIgnoreCase
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+
+object FilterCmiWarp : Filter<NoCompileData, List<String>>("cmi_warp") {
+    override val description = "Matches when the player used one of the given CMI warps."
+    override val categories = setOf("player")
+    override val valueType = ArgType.STRING_LIST
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "Passes automatically when the event is not a CMI warp event."
+    )
+
+    override fun getValue(config: Config, data: TriggerData?, key: String): List<String> {
+        return config.getStrings(key)
+    }
+
+    override fun isMet(data: TriggerData, value: List<String>, compileData: NoCompileData): Boolean {
+        val event = data.event as? CMIPlayerWarpEvent ?: return true
+
+        return value.containsIgnoreCase(event.warp?.name ?: return false)
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/MutatorCmiLocationToHome.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/MutatorCmiLocationToHome.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.mutators.Mutator
+import com.willfp.libreforge.mutators.parameterTransformers
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object MutatorCmiLocationToHome : Mutator<NoCompileData>("cmi_location_to_home") {
+    override val description = "Sets the location to the location of one of the player's CMI homes."
+    override val categories = setOf("location", "player")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "No-ops if there is no player, or if the player has no home with the given name."
+    )
+
+    override val parameterTransformers = parameterTransformers {
+        TriggerParameter.PLAYER becomes TriggerParameter.LOCATION
+    }
+
+    override val arguments = arguments {
+        require(
+            "home",
+            "You must specify the home name!",
+            description = "The name of the player's CMI home to read the location from.",
+            type = ArgType.STRING
+        )
+    }
+
+    override fun mutate(data: TriggerData, config: Config, compileData: NoCompileData): TriggerData {
+        val player = data.player ?: return data
+        val user = CMI.getInstance()?.playerManager?.getUser(player) ?: return data
+        val location = user.getHome(config.getString("home"))?.loc?.bukkitLoc ?: return data
+
+        return data.copy(
+            location = location
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/MutatorCmiLocationToWarp.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/MutatorCmiLocationToWarp.kt
@@ -1,0 +1,45 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.CMI
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.ArgType
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.mutators.Mutator
+import com.willfp.libreforge.mutators.parameterTransformers
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+
+object MutatorCmiLocationToWarp : Mutator<NoCompileData>("cmi_location_to_warp") {
+    override val description = "Sets the location to the location of a CMI warp."
+    override val categories = setOf("location")
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "No-ops if no warp with the given name exists."
+    )
+
+    override val parameterTransformers = parameterTransformers {
+        adds(TriggerParameter.LOCATION)
+    }
+
+    override val arguments = arguments {
+        require(
+            "warp",
+            "You must specify the warp name!",
+            description = "The name of the CMI warp to read the location from.",
+            type = ArgType.STRING
+        )
+    }
+
+    override fun mutate(data: TriggerData, config: Config, compileData: NoCompileData): TriggerData {
+        val location = CMI.getInstance()?.warpManager
+            ?.getWarp(config.getString("warp"))
+            ?.loc
+            ?.bukkitLoc
+            ?: return data
+
+        return data.copy(
+            location = location
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiAfkEnter.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiAfkEnter.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIAfkEnterEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiAfkEnter : Trigger("cmi_afk_enter") {
+    override val description = "Fires when the player goes AFK."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.TEXT to "How the player went AFK, either auto or manual."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIAfkEnterEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                text = event.type?.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiAfkLeave.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiAfkLeave.kt
@@ -1,0 +1,47 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIAfkLeaveEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiAfkLeave : Trigger("cmi_afk_leave") {
+    override val description = "Fires when the player stops being AFK."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin.",
+        "The value is the number of seconds the player was AFK for."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.VALUE to "The number of seconds the player was AFK for.",
+        TriggerParameter.TEXT to "The reason the player stopped being AFK."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.VALUE,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler
+    fun handle(event: CMIAfkLeaveEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                value = event.time / 1000.0,
+                text = event.reason
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiBalanceChange.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiBalanceChange.kt
@@ -1,0 +1,49 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIUserBalanceChangeEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiBalanceChange : Trigger("cmi_balance_change") {
+    override val description = "Fires when the player's CMI balance changes."
+
+    override val categories = setOf("economy", "player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.VALUE to "The amount the balance changed by, negative when money was taken.",
+        TriggerParameter.ALT_VALUE to "The new balance.",
+        TriggerParameter.TEXT to "The action type that caused the change."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.VALUE,
+        TriggerParameter.ALT_VALUE,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler
+    fun handle(event: CMIUserBalanceChangeEvent) {
+        val player = event.user?.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                value = event.to - event.from,
+                altValue = event.to,
+                text = event.actionType
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiChequeCreate.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiChequeCreate.kt
@@ -1,0 +1,46 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIChequeCreationEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiChequeCreate : Trigger("cmi_cheque_create") {
+    override val description = "Fires when the player writes a CMI cheque."
+
+    override val categories = setOf("economy", "player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.VALUE to "The value written on the cheque.",
+        TriggerParameter.ITEM to "The cheque item."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.VALUE,
+        TriggerParameter.ITEM
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIChequeCreationEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                value = event.price,
+                item = event.cheque
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiChequeUse.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiChequeUse.kt
@@ -1,0 +1,46 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIChequeUsageEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiChequeUse : Trigger("cmi_cheque_use") {
+    override val description = "Fires when the player redeems a CMI cheque."
+
+    override val categories = setOf("economy", "player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.VALUE to "The value written on the cheque.",
+        TriggerParameter.ITEM to "The cheque item."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.VALUE,
+        TriggerParameter.ITEM
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIChequeUsageEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                value = event.price,
+                item = event.cheque
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiHomeCreate.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiHomeCreate.kt
@@ -1,0 +1,44 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIUserHomeCreateEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiHomeCreate : Trigger("cmi_home_create") {
+    override val description = "Fires when the player sets a home."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The location of the home.",
+        TriggerParameter.TEXT to "The name of the home."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIUserHomeCreateEvent) {
+        val player = event.user?.player ?: return
+        val home = event.home ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = home.loc?.bukkitLoc,
+                text = home.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiHomeRemove.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiHomeRemove.kt
@@ -1,0 +1,44 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIUserHomeRemoveEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiHomeRemove : Trigger("cmi_home_remove") {
+    override val description = "Fires when the player deletes a home."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The location of the home.",
+        TriggerParameter.TEXT to "The name of the home."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIUserHomeRemoveEvent) {
+        val player = event.user?.player ?: return
+        val home = event.home ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = home.loc?.bukkitLoc,
+                text = home.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiJail.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiJail.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerJailEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiJail : Trigger("cmi_jail") {
+    override val description = "Fires when the player is jailed."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.TEXT to "The name of the jail the player was sent to."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerJailEvent) {
+        val player = event.user?.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                text = event.cell?.jail?.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiKitAcquire.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiKitAcquire.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIUserKitAcquireEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiKitAcquire : Trigger("cmi_kit_acquire") {
+    override val description = "Fires when the player claims a kit."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.TEXT to "The name of the kit."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIUserKitAcquireEvent) {
+        val player = event.user?.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                text = event.kit?.configName
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiNicknameChange.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiNicknameChange.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerNickNameChangeEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiNicknameChange : Trigger("cmi_nickname_change") {
+    override val description = "Fires when the player's nickname is changed."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.TEXT to "The new nickname."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerNickNameChangeEvent) {
+        val player = event.user?.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                text = event.nickName
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiPortalUse.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiPortalUse.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPortalUseEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiPortalUse : Trigger("cmi_portal_use") {
+    override val description = "Fires when the player goes through a CMI portal."
+
+    override val categories = setOf("player", "world")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.TEXT to "The name of the portal."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPortalUseEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                text = event.portal?.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiSellItems.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiSellItems.kt
@@ -1,0 +1,49 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerItemsSellEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiSellItems : Trigger("cmi_sell_items") {
+    override val description = "Fires when the player sells items through CMI."
+
+    override val categories = setOf("economy", "player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.VALUE to "The total amount of money paid out.",
+        TriggerParameter.ALT_VALUE to "The total number of items sold.",
+        TriggerParameter.TEXT to "The sell type, one of all, hand, blocks, same, material, or gui."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.VALUE,
+        TriggerParameter.ALT_VALUE,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler
+    fun handle(event: CMIPlayerItemsSellEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                value = event.totalPayment,
+                altValue = event.totalAmount.toDouble(),
+                text = event.sellType?.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiSit.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiSit.kt
@@ -1,0 +1,40 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerSitEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiSit : Trigger("cmi_sit") {
+    override val description = "Fires when the player sits down."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerSitEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiTeleportRequest.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiTeleportRequest.kt
@@ -1,0 +1,46 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerTeleportRequestEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiTeleportRequest : Trigger("cmi_teleport_request") {
+    override val description = "Fires when the player sends a teleport request to another player."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.VICTIM to "The player who received the request.",
+        TriggerParameter.LOCATION to "The requesting player's location.",
+        TriggerParameter.TEXT to "The type of request, e.g. tpa, tpahere, tpaall."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.VICTIM,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerTeleportRequestEvent) {
+        val player = event.whoOffers ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                victim = event.whoAccepts,
+                location = player.location,
+                text = event.action?.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiUnjail.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiUnjail.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerUnjailEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiUnjail : Trigger("cmi_unjail") {
+    override val description = "Fires when the player is released from jail."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.TEXT to "The name of the jail the player was released from."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler
+    fun handle(event: CMIPlayerUnjailEvent) {
+        val player = event.user?.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                text = event.cell?.jail?.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiUnvanish.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiUnvanish.kt
@@ -1,0 +1,40 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerUnVanishEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiUnvanish : Trigger("cmi_unvanish") {
+    override val description = "Fires when the player stops being vanished."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerUnVanishEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiVanish.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiVanish.kt
@@ -1,0 +1,40 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerVanishEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiVanish : Trigger("cmi_vanish") {
+    override val description = "Fires when the player vanishes."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerVanishEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiWarn.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiWarn.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerWarnEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiWarn : Trigger("cmi_warn") {
+    override val description = "Fires when the player is given a warning."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The player's location.",
+        TriggerParameter.TEXT to "The reason for the warning."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerWarnEvent) {
+        val player = event.user?.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = player.location,
+                text = event.warning?.reason
+            )
+        )
+    }
+}

--- a/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiWarpUse.kt
+++ b/core/common/src/main/kotlin/com/willfp/libreforge/integrations/cmi/impl/TriggerCmiWarpUse.kt
@@ -1,0 +1,43 @@
+package com.willfp.libreforge.integrations.cmi.impl
+
+import com.Zrips.CMI.events.CMIPlayerWarpEvent
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import org.bukkit.event.EventHandler
+
+object TriggerCmiWarpUse : Trigger("cmi_warp_use") {
+    override val description = "Fires when the player uses a warp."
+
+    override val categories = setOf("player")
+
+    override val additionalInfo = listOf(
+        "Requires the CMI plugin."
+    )
+
+    override val parameterDescriptions = mapOf(
+        TriggerParameter.LOCATION to "The location of the warp.",
+        TriggerParameter.TEXT to "The name of the warp."
+    )
+
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: CMIPlayerWarpEvent) {
+        val player = event.player ?: return
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                location = event.warp?.loc?.bukkitLoc,
+                text = event.warp?.name
+            )
+        )
+    }
+}

--- a/core/common/src/main/resources/plugin.yml
+++ b/core/common/src/main/resources/plugin.yml
@@ -14,6 +14,7 @@ website: willfp.com
 softdepend:
   - eco
   - Jobs
+  - CMI
   - LevelledMobs
   - mcMMO
   - Scyther


### PR DESCRIPTION
### Description

Added integration for [CMI](https://www.spigotmc.org/resources/cmi-300-commands-insane-kits-portals-essentials-economy-mysql-sqlite-much-more.3742/), an Essentials-esc project. 

Adds:
- 19 Triggers 
  - cmi_balance_change
  - cmi_cheque_create
  - cmi_cheque_use
  - cmi_sell_items
  - cmi_afk_enter
  - cmi_afk_leave
  - cmi_vanish
  - cmi_unvanish
  - cmi_jail
  - cmi_unjail
  - cmi_nickname_change
  - cmi_warn
  - cmi_sit
  - cmi_home_create
  - cmi_home_remove
  - cmi_warp_use
  - cmi_portal_use
  - cmi_teleport_request
  - cmi_kit_acquire
- 10 Conditions
  - cmi_is_afk
  - cmi_is_vanished
  - cmi_is_jailed
  - cmi_is_muted
  - cmi_is_god
  - cmi_has_rank
  - cmi_playtime_above
  - cmi_balance_above
  - cmi_kit_available
  - cmi_statistic_above
- 5 Effects
  - cmi_give_balance
  - cmi_take_balance
  - cmi_set_balance
  - cmi_give_kit
  - cmi_teleport_to_warp
- 4 Filters
  - cmi_warp
  - cmi_portal
  - cmi_kit
  - cmi_sell_type
- 2 Mutators
  - cmi_location_to_warp
  - cmi_location_to_home

This integration is powered by the `CMI-API` at version [9.8.6.4](https://github.com/Zrips/CMI-API/releases/tag/9.8.6.4) - requiring `CMILib` at version [1.5.8.1](https://github.com/Zrips/CMILib/releases/tag/1.5.8.1).